### PR TITLE
fix(web): Lighthouse CI - MSW auth + PWA/SEO/a11y gaps

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -150,6 +150,8 @@ jobs:
 
       - name: Build app
         run: pnpm --filter @ganatrack/web build
+        env:
+          NEXT_PUBLIC_MSW_ENABLED: 'true'
 
       - name: Start server and run Lighthouse Desktop
         run: |
@@ -159,6 +161,7 @@ jobs:
         working-directory: apps/web
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          NEXT_PUBLIC_MSW_ENABLED: 'true'
 
       - name: Upload Lighthouse Desktop report
         uses: actions/upload-artifact@v4
@@ -191,6 +194,8 @@ jobs:
 
       - name: Build app
         run: pnpm --filter @ganatrack/web build
+        env:
+          NEXT_PUBLIC_MSW_ENABLED: 'true'
 
       - name: Start server and run Lighthouse Mobile
         run: |
@@ -200,6 +205,7 @@ jobs:
         working-directory: apps/web
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          NEXT_PUBLIC_MSW_ENABLED: 'true'
 
       - name: Upload Lighthouse Mobile report
         uses: actions/upload-artifact@v4

--- a/apps/web/.lighthouserc.desktop.json
+++ b/apps/web/.lighthouserc.desktop.json
@@ -2,22 +2,28 @@
   "ci": {
     "collect": [
       {
+        "url": ["http://localhost:3000/login"],
+        "settings": {
+          "preset": "desktop",
+          "formFactor": "desktop",
+          "channel": "chrome",
+          "skipAudits": ["uses-http2", "uses-long-cache-ttl"]
+        }
+      },
+      {
         "url": [
-          "http://localhost:3000/login",
           "http://localhost:3000/dashboard",
           "http://localhost:3000/dashboard/animales",
           "http://localhost:3000/dashboard/predios",
           "http://localhost:3000/dashboard/usuarios",
           "http://localhost:3000/dashboard/sincronizacion"
         ],
+        "puppeteerScript": "./scripts/lighthouse-auth.js",
         "settings": {
           "preset": "desktop",
           "formFactor": "desktop",
           "channel": "chrome",
-          "skipAudits": [
-            "uses-http2",
-            "uses-long-cache-ttl"
-          ]
+          "skipAudits": ["uses-http2", "uses-long-cache-ttl"]
         }
       }
     ],

--- a/apps/web/.lighthouserc.json
+++ b/apps/web/.lighthouserc.json
@@ -56,9 +56,6 @@
             "downloadThroughputKbps": 1638.4,
             "uploadThroughputKbps": 675,
             "rttMs": 150
-          },
-          "assertions": {
-            "categories:performance": ["warn", { "minScore": 0.70 }]
           }
         }
       }

--- a/apps/web/.lighthouserc.json
+++ b/apps/web/.lighthouserc.json
@@ -2,33 +2,52 @@
   "ci": {
     "collect": [
       {
-        "url": [
-          "http://localhost:3000/login",
-          "http://localhost:3000/dashboard",
-          "http://localhost:3000/dashboard/animales",
-          "http://localhost:3000/dashboard/predios",
-          "http://localhost:3000/dashboard/usuarios",
-          "http://localhost:3000/dashboard/sincronizacion"
-        ],
+        "url": ["http://localhost:3000/login"],
         "settings": {
           "preset": "desktop",
           "formFactor": "desktop",
           "channel": "chrome",
-          "skipAudits": [
-            "uses-http2",
-            "uses-long-cache-ttl"
-          ]
+          "skipAudits": ["uses-http2", "uses-long-cache-ttl"]
         }
       },
       {
         "url": [
-          "http://localhost:3000/login",
           "http://localhost:3000/dashboard",
           "http://localhost:3000/dashboard/animales",
           "http://localhost:3000/dashboard/predios",
           "http://localhost:3000/dashboard/usuarios",
           "http://localhost:3000/dashboard/sincronizacion"
         ],
+        "puppeteerScript": "./scripts/lighthouse-auth.js",
+        "settings": {
+          "preset": "desktop",
+          "formFactor": "desktop",
+          "channel": "chrome",
+          "skipAudits": ["uses-http2", "uses-long-cache-ttl"]
+        }
+      },
+      {
+        "url": ["http://localhost:3000/login"],
+        "settings": {
+          "preset": "mobile",
+          "formFactor": "mobile",
+          "throttling": {
+            "cpuSlowdownMultiplier": 4,
+            "downloadThroughputKbps": 1638.4,
+            "uploadThroughputKbps": 675,
+            "rttMs": 150
+          }
+        }
+      },
+      {
+        "url": [
+          "http://localhost:3000/dashboard",
+          "http://localhost:3000/dashboard/animales",
+          "http://localhost:3000/dashboard/predios",
+          "http://localhost:3000/dashboard/usuarios",
+          "http://localhost:3000/dashboard/sincronizacion"
+        ],
+        "puppeteerScript": "./scripts/lighthouse-auth.js",
         "settings": {
           "preset": "mobile",
           "formFactor": "mobile",

--- a/apps/web/.lighthouserc.mobile.json
+++ b/apps/web/.lighthouserc.mobile.json
@@ -2,14 +2,27 @@
   "ci": {
     "collect": [
       {
+        "url": ["http://localhost:3000/login"],
+        "settings": {
+          "preset": "mobile",
+          "formFactor": "mobile",
+          "throttling": {
+            "cpuSlowdownMultiplier": 4,
+            "downloadThroughputKbps": 1638.4,
+            "uploadThroughputKbps": 675,
+            "rttMs": 150
+          }
+        }
+      },
+      {
         "url": [
-          "http://localhost:3000/login",
           "http://localhost:3000/dashboard",
           "http://localhost:3000/dashboard/animales",
           "http://localhost:3000/dashboard/predios",
           "http://localhost:3000/dashboard/usuarios",
           "http://localhost:3000/dashboard/sincronizacion"
         ],
+        "puppeteerScript": "./scripts/lighthouse-auth.js",
         "settings": {
           "preset": "mobile",
           "formFactor": "mobile",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -87,5 +87,10 @@
     "typescript": "^5.9.3",
     "vitest": "^2.1.9",
     "wait-on": "^8.0.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,4 +1,5 @@
 {
+  "id": "/",
   "name": "GanaTrack — Sistema de gestión ganadera",
   "short_name": "GanaTrack",
   "description": "Sistema de gestión ganadera para el manejo de hatos, reproducción y sanidad",
@@ -14,13 +15,25 @@
       "src": "/icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "/icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ],
   "shortcuts": [

--- a/apps/web/public/mockServiceWorker.js
+++ b/apps/web/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.13.2'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -4,4 +4,3 @@ Disallow: /dashboard/
 Allow: /login
 Allow: /
 
-Sitemap: /sitemap.xml

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /api/
+Disallow: /dashboard/
+Allow: /login
+Allow: /
+
+Sitemap: /sitemap.xml

--- a/apps/web/scripts/lighthouse-auth.js
+++ b/apps/web/scripts/lighthouse-auth.js
@@ -1,0 +1,51 @@
+// apps/web/scripts/lighthouse-auth.js
+/**
+ * LHCI Puppeteer pre-audit script.
+ *
+ * Runs before each Lighthouse collection on authenticated dashboard URLs.
+ * Sets the gt-auth cookie (middleware checks existence only) and seeds the
+ * MSW mock admin user so GET /api/v1/auth/me returns a valid profile.
+ *
+ * @param {import('puppeteer').Browser} browser
+ * @param {{ url: string }} context
+ */
+module.exports = async (browser, context) => {
+  const origin = new URL(context.url).origin;
+  const page = await browser.newPage();
+
+  // Set auth cookie — middleware only checks that it EXISTS, value is irrelevant
+  await page.setCookie({
+    name: 'gt-auth',
+    value: 'ci-test-session',
+    url: origin,
+    httpOnly: false,
+    sameSite: 'Lax',
+  });
+
+  // Navigate to dashboard to trigger MswProvider boot and worker.start()
+  await page.goto(`${origin}/dashboard`, { waitUntil: 'networkidle0' });
+
+  // Wait for MswProvider to expose window.__mswSetUser (max 15s)
+  await page.waitForFunction(
+    () => typeof window.__mswSetUser === 'function',
+    { timeout: 15000 }
+  );
+
+  // Seed the mock admin user for the auth/me handler
+  await page.evaluate(() => {
+    window.__mswSetUser({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      email: 'admin@ganatrack.com',
+      nombre: 'Admin Ganatrack',
+      rol: 'admin',
+    });
+  });
+
+  // Verify MSW responds correctly before handing control back to LHCI
+  await page.evaluate(async () => {
+    const res = await fetch('/api/v1/auth/me', { credentials: 'include' });
+    if (!res.ok) throw new Error(`MSW auth/me returned ${res.status}`);
+  });
+
+  await page.close();
+};

--- a/apps/web/scripts/lighthouse-auth.js
+++ b/apps/web/scripts/lighthouse-auth.js
@@ -13,39 +13,44 @@ module.exports = async (browser, context) => {
   const origin = new URL(context.url).origin;
   const page = await browser.newPage();
 
-  // Set auth cookie — middleware only checks that it EXISTS, value is irrelevant
-  await page.setCookie({
-    name: 'gt-auth',
-    value: 'ci-test-session',
-    url: origin,
-    httpOnly: false,
-    sameSite: 'Lax',
-  });
-
-  // Navigate to dashboard to trigger MswProvider boot and worker.start()
-  await page.goto(`${origin}/dashboard`, { waitUntil: 'networkidle0' });
-
-  // Wait for MswProvider to expose window.__mswSetUser (max 15s)
-  await page.waitForFunction(
-    () => typeof window.__mswSetUser === 'function',
-    { timeout: 15000 }
-  );
-
-  // Seed the mock admin user for the auth/me handler
-  await page.evaluate(() => {
-    window.__mswSetUser({
-      id: '550e8400-e29b-41d4-a716-446655440000',
-      email: 'admin@ganatrack.com',
-      nombre: 'Admin Ganatrack',
-      rol: 'admin',
+  try {
+    // Set auth cookie — middleware only checks that it EXISTS, value is irrelevant
+    await page.setCookie({
+      name: 'gt-auth',
+      value: 'ci-test-session',
+      url: origin,
+      httpOnly: false,
+      sameSite: 'Lax',
     });
-  });
 
-  // Verify MSW responds correctly before handing control back to LHCI
-  await page.evaluate(async () => {
-    const res = await fetch('/api/v1/auth/me', { credentials: 'include' });
-    if (!res.ok) throw new Error(`MSW auth/me returned ${res.status}`);
-  });
+    // Navigate to dashboard to trigger MswProvider boot and worker.start().
+    // Use domcontentloaded (not networkidle0) — initial React Query requests may
+    // fail before MSW is ready; waiting for networkidle0 can hang on those retries.
+    // The waitForFunction below is the real gating mechanism.
+    await page.goto(`${origin}/dashboard`, { waitUntil: 'domcontentloaded' });
 
-  await page.close();
+    // Wait for MswProvider to expose window.__mswSetUser (max 15s)
+    await page.waitForFunction(
+      () => typeof window.__mswSetUser === 'function',
+      { timeout: 15000 }
+    );
+
+    // Seed the mock admin user for the auth/me handler
+    await page.evaluate(() => {
+      window.__mswSetUser({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        email: 'admin@ganatrack.com',
+        nombre: 'Admin Ganatrack',
+        rol: 'admin',
+      });
+    });
+
+    // Verify MSW responds correctly before handing control back to LHCI
+    await page.evaluate(async () => {
+      const res = await fetch('/api/v1/auth/me', { credentials: 'include' });
+      if (!res.ok) throw new Error(`auth/me returned ${res.status} — MSW may not be running`);
+    });
+  } finally {
+    await page.close();
+  }
 };

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -19,9 +19,9 @@ interface AuthLayoutProps {
 export default function AuthLayout({ children }: AuthLayoutProps): JSX.Element {
   return (
     <ErrorBoundary>
-      <div className="flex items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900">
+      <main id="main-content" className="flex items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900">
         {children}
-      </div>
+      </main>
     </ErrorBoundary>
   );
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Outfit } from "next/font/google";
 import { AppProviders } from "@/shared/providers/app-providers";
 import { ToastProvider } from "@/shared/components/feedback";
 import { SerwistProvider } from "./serwist";
+import { MswProvider } from "./msw-provider";
 import "./globals.css";
 
 const outfit = Outfit({
@@ -89,9 +90,11 @@ export default function RootLayout({
           Saltar al contenido principal
         </a>
 
-        <SerwistProvider swUrl="/serwist/sw.js">
-          <AppProviders>{children}</AppProviders>
-        </SerwistProvider>
+        <MswProvider>
+          <SerwistProvider swUrl="/serwist/sw.js">
+            <AppProviders>{children}</AppProviders>
+          </SerwistProvider>
+        </MswProvider>
 
         <ToastProvider />
       </body>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -89,7 +89,7 @@ export default function RootLayout({
           Saltar al contenido principal
         </a>
 
-        <SerwistProvider swUrl="/sw.js">
+        <SerwistProvider swUrl="/serwist/sw.js">
           <AppProviders>{children}</AppProviders>
         </SerwistProvider>
 

--- a/apps/web/src/app/msw-provider.tsx
+++ b/apps/web/src/app/msw-provider.tsx
@@ -7,39 +7,37 @@
  */
 'use client';
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 
 const MSW_ENABLED = process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
 
 export function MswProvider({ children }: { children: ReactNode }) {
-  const [ready, setReady] = useState(!MSW_ENABLED);
-
   useEffect(() => {
     if (!MSW_ENABLED || typeof window === 'undefined') return;
 
     let cancelled = false;
 
     void (async () => {
-      const { startMockService, setMockUser } = await import('@/tests/mocks/browser');
-      await startMockService();
-      // Expose setter so the LHCI puppeteer script can re-seed the user per URL
-      (window as Window & { __mswSetUser?: typeof setMockUser }).__mswSetUser = setMockUser;
-      // Seed default CI admin user
-      setMockUser({
-        id: '550e8400-e29b-41d4-a716-446655440000',
-        email: 'admin@ganatrack.com',
-        nombre: 'Admin Ganatrack',
-        rol: 'admin',
-      });
-      if (!cancelled) setReady(true);
+      try {
+        const { startMockService, setMockUser } = await import('@/tests/mocks/browser');
+        await startMockService();
+        if (cancelled) return;
+        // Expose setter so the LHCI puppeteer script can re-seed the user per URL
+        (window as Window & { __mswSetUser?: typeof setMockUser }).__mswSetUser = setMockUser;
+        // Seed default CI admin user
+        setMockUser({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          email: 'admin@ganatrack.com',
+          nombre: 'Admin Ganatrack',
+          rol: 'admin',
+        });
+      } catch (err) {
+        if (!cancelled) console.error('[MswProvider] Failed to initialize MSW:', err);
+      }
     })();
 
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, []);
-
-  if (!ready) return null;
 
   return <>{children}</>;
 }

--- a/apps/web/src/app/msw-provider.tsx
+++ b/apps/web/src/app/msw-provider.tsx
@@ -1,0 +1,45 @@
+// apps/web/src/app/msw-provider.tsx
+/**
+ * MSW Provider — conditionally starts the MSW browser worker in CI/LHCI environments.
+ *
+ * Only active when NEXT_PUBLIC_MSW_ENABLED=true (set only in lighthouse CI jobs).
+ * Production builds tree-shake all MSW code when env var is unset.
+ */
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+
+const MSW_ENABLED = process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
+
+export function MswProvider({ children }: { children: ReactNode }) {
+  const [ready, setReady] = useState(!MSW_ENABLED);
+
+  useEffect(() => {
+    if (!MSW_ENABLED || typeof window === 'undefined') return;
+
+    let cancelled = false;
+
+    void (async () => {
+      const { startMockService, setMockUser } = await import('@/tests/mocks/browser');
+      await startMockService();
+      // Expose setter so the LHCI puppeteer script can re-seed the user per URL
+      (window as Window & { __mswSetUser?: typeof setMockUser }).__mswSetUser = setMockUser;
+      // Seed default CI admin user
+      setMockUser({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        email: 'admin@ganatrack.com',
+        nombre: 'Admin Ganatrack',
+        rol: 'admin',
+      });
+      if (!cancelled) setReady(true);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!ready) return null;
+
+  return <>{children}</>;
+}

--- a/apps/web/src/app/serwist/[path]/route.ts
+++ b/apps/web/src/app/serwist/[path]/route.ts
@@ -7,7 +7,7 @@ const revision =
 
 export const { dynamic, dynamicParams, revalidate, generateStaticParams, GET } =
   createSerwistRoute({
-    additionalPrecacheEntries: [{ url: "/~offline", revision }],
+    additionalPrecacheEntries: [{ url: "/offline", revision }],
     swSrc: "src/sw.ts",
     useNativeEsbuild: true,
   });

--- a/apps/web/src/shared/providers/auth-provider.tsx
+++ b/apps/web/src/shared/providers/auth-provider.tsx
@@ -60,7 +60,10 @@ export function AuthProvider({ children }: AuthProviderProps): JSX.Element {
       // In production mode (no mocks), skip rehydration entirely
       // The auth state is managed by the login/logout hooks and Zustand persistence
       // The middleware protects routes, and the first API call will handle token refresh
-      const useMocks = process.env.NEXT_PUBLIC_USE_MOCKS === 'true';
+      // NEXT_PUBLIC_MSW_ENABLED covers LHCI CI runs — MSW intercepts getMe() for mock data
+      const useMocks =
+        process.env.NEXT_PUBLIC_USE_MOCKS === 'true' ||
+        process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
       if (!useMocks) {
         setIsHydrating(false);
         return;

--- a/apps/web/src/sw.ts
+++ b/apps/web/src/sw.ts
@@ -25,8 +25,8 @@
  * - Offline fallback navigation
  */
 
-import { defaultCache } from "@serwist/turbopack/worker";
 import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
+import { get as idbGet, set as idbSet, del as idbDel } from "idb-keyval";
 import {
   Serwist,
   CacheFirst,
@@ -220,7 +220,7 @@ const serwist = new Serwist({
   runtimeCaching: [
     // 1. Static assets — StaleWhileRevalidate
     {
-      urlPattern: ({ url }) => url.pathname.startsWith("/_next/static/"),
+      matcher: ({ url }) => url.pathname.startsWith("/_next/static/"),
       handler: new StaleWhileRevalidate({
         cacheName: "static-resources",
       }),
@@ -228,7 +228,7 @@ const serwist = new Serwist({
 
     // 2. Images (icons, uploaded images) — CacheFirst
     {
-      urlPattern: ({ url }) =>
+      matcher: ({ url }) =>
         url.pathname.startsWith("/icons/") || url.pathname.startsWith("/images/"),
       handler: new CacheFirst({
         cacheName: "static-images",
@@ -240,13 +240,13 @@ const serwist = new Serwist({
 
     // 3. Auth — NEVER cache (NetworkOnly)
     {
-      urlPattern: ({ url }) => url.pathname.startsWith("/api/v1/auth/"),
+      matcher: ({ url }) => url.pathname.startsWith("/api/v1/auth/"),
       handler: new NetworkOnly(),
     },
 
     // 4. API images (animal photos, hierros) — CacheFirst
     {
-      urlPattern: ({ url }) => url.pathname.startsWith("/api/v1/imagenes/"),
+      matcher: ({ url }) => url.pathname.startsWith("/api/v1/imagenes/"),
       handler: new CacheFirst({
         cacheName: "api-images",
         plugins: [
@@ -257,7 +257,7 @@ const serwist = new Serwist({
 
     // 5. Catalogs — StaleWhileRevalidate (rarely change)
     {
-      urlPattern: ({ url }) =>
+      matcher: ({ url }) =>
         /\/api\/v1\/(configuracion|maestros)\//.test(url.pathname),
       handler: new StaleWhileRevalidate({ cacheName: "api-catalogs" }),
       method: "GET",
@@ -265,7 +265,7 @@ const serwist = new Serwist({
 
     // 6. Dynamic API — NetworkFirst with 3s timeout
     {
-      urlPattern: ({ url }) => url.pathname.startsWith("/api/v1/"),
+      matcher: ({ url }) => url.pathname.startsWith("/api/v1/"),
       handler: new NetworkFirst({
         cacheName: "api-dynamic",
         networkTimeoutSeconds: 3,
@@ -278,7 +278,7 @@ const serwist = new Serwist({
 
     // 7. Mutations POST — NetworkOnly + BackgroundSync (exclude auth)
     {
-      urlPattern: ({ url }) =>
+      matcher: ({ url }) =>
         url.pathname.startsWith("/api/v1/") &&
         !url.pathname.startsWith("/api/v1/auth/"),
       handler: createMutationHandler("mutation-queue-post"),
@@ -287,7 +287,7 @@ const serwist = new Serwist({
 
     // 7b. Mutations PUT — NetworkOnly + BackgroundSync (exclude auth)
     {
-      urlPattern: ({ url }) =>
+      matcher: ({ url }) =>
         url.pathname.startsWith("/api/v1/") &&
         !url.pathname.startsWith("/api/v1/auth/"),
       handler: createMutationHandler("mutation-queue-put"),
@@ -296,7 +296,7 @@ const serwist = new Serwist({
 
     // 7c. Mutations DELETE — NetworkOnly + BackgroundSync (exclude auth)
     {
-      urlPattern: ({ url }) =>
+      matcher: ({ url }) =>
         url.pathname.startsWith("/api/v1/") &&
         !url.pathname.startsWith("/api/v1/auth/"),
       handler: createMutationHandler("mutation-queue-delete"),
@@ -305,7 +305,7 @@ const serwist = new Serwist({
 
     // 8. Google Fonts — CacheFirst, 1 year
     {
-      urlPattern: ({ url }) =>
+      matcher: ({ url }) =>
         /^https:\/\/fonts\.(googleapis|gstatic)\.com/.test(url.href),
       handler: new CacheFirst({
         cacheName: "google-fonts",
@@ -380,9 +380,8 @@ export async function replayWithTokenRefresh(
  */
 export async function moveToFailedSyncQueue(item: SyncQueueItem): Promise<void> {
   try {
-    const { set, get } = await import('idb-keyval');
-    const items: SyncQueueItem[] = (await get('ganatrack-failed-sync')) ?? [];
-    
+    const items: SyncQueueItem[] = (await idbGet('ganatrack-failed-sync')) ?? [];
+
     // Replace if same URL, otherwise add
     const existingIndex = items.findIndex((i) => i.url === item.url);
     if (existingIndex >= 0) {
@@ -390,8 +389,8 @@ export async function moveToFailedSyncQueue(item: SyncQueueItem): Promise<void> 
     } else {
       items.push(item);
     }
-    
-    await set('ganatrack-failed-sync', items);
+
+    await idbSet('ganatrack-failed-sync', items);
     notifyClient({ type: 'SYNC_QUEUE_UPDATED' });
   } catch (error) {
     console.error('[SW] Failed to move item to failed-sync queue:', error);
@@ -405,17 +404,16 @@ export async function moveToFailedSyncQueue(item: SyncQueueItem): Promise<void> 
  */
 export async function moveToConflictQueue(item: SyncQueueItem): Promise<void> {
   try {
-    const { set, get } = await import('idb-keyval');
-    const items: SyncQueueItem[] = (await get('ganatrack-conflict-queue')) ?? [];
-    
+    const items: SyncQueueItem[] = (await idbGet('ganatrack-conflict-queue')) ?? [];
+
     const existingIndex = items.findIndex((i) => i.url === item.url);
     if (existingIndex >= 0) {
       items[existingIndex] = item;
     } else {
       items.push(item);
     }
-    
-    await set('ganatrack-conflict-queue', items);
+
+    await idbSet('ganatrack-conflict-queue', items);
     notifyClient({ type: 'CONFLICT_DETECTED', payload: { url: item.url } });
   } catch (error) {
     console.error('[SW] Failed to move item to conflict queue:', error);
@@ -559,10 +557,8 @@ self.addEventListener('message', (event) => {
       break;
 
     case 'CLEAR_SYNC_QUEUES':
-      void import('idb-keyval').then(({ del }) => {
-        void del('ganatrack-failed-sync');
-        void del('ganatrack-conflict-queue');
-      });
+      void idbDel('ganatrack-failed-sync');
+      void idbDel('ganatrack-conflict-queue');
       break;
 
     case 'GET_SYNC_STATUS':
@@ -576,10 +572,9 @@ self.addEventListener('message', (event) => {
         const { url } = event.data?.payload || {};
         if (url) {
           try {
-            const { set, get } = await import('idb-keyval');
-            const failedItems: SyncQueueItem[] = (await get('ganatrack-failed-sync')) ?? [];
+            const failedItems: SyncQueueItem[] = (await idbGet('ganatrack-failed-sync')) ?? [];
             const filtered = failedItems.filter((item) => item.url !== url);
-            await set('ganatrack-failed-sync', filtered);
+            await idbSet('ganatrack-failed-sync', filtered);
             notifyClient({ type: 'SYNC_QUEUE_UPDATED' });
           } catch (error) {
             console.error('[SW] Failed to discard sync item:', error);
@@ -594,10 +589,9 @@ self.addEventListener('message', (event) => {
         const { url } = event.data?.payload || {};
         if (url) {
           try {
-            const { set, get } = await import('idb-keyval');
-            const conflictItems: SyncQueueItem[] = (await get('ganatrack-conflict-queue')) ?? [];
+            const conflictItems: SyncQueueItem[] = (await idbGet('ganatrack-conflict-queue')) ?? [];
             const filtered = conflictItems.filter((item) => item.url !== url);
-            await set('ganatrack-conflict-queue', filtered);
+            await idbSet('ganatrack-conflict-queue', filtered);
             notifyClient({ type: 'SYNC_QUEUE_UPDATED' });
           } catch (error) {
             console.error('[SW] Failed to discard conflict item:', error);
@@ -635,10 +629,9 @@ async function getSyncStatus(): Promise<{
   conflictCount: number;
 }> {
   try {
-    const { get } = await import('idb-keyval');
-    const failedItems = (await get<SyncQueueItem[]>('ganatrack-failed-sync')) ?? [];
-    const conflictItems = (await get<SyncQueueItem[]>('ganatrack-conflict-queue')) ?? [];
-    
+    const failedItems = (await idbGet<SyncQueueItem[]>('ganatrack-failed-sync')) ?? [];
+    const conflictItems = (await idbGet<SyncQueueItem[]>('ganatrack-conflict-queue')) ?? [];
+
     return {
       failedCount: failedItems.length,
       conflictCount: conflictItems.length,

--- a/apps/web/src/tests/mocks/browser.ts
+++ b/apps/web/src/tests/mocks/browser.ts
@@ -1,0 +1,20 @@
+// apps/web/src/tests/mocks/browser.ts
+/**
+ * MSW browser worker setup for LHCI and local CI testing.
+ *
+ * Used by MswProvider (src/app/msw-provider.tsx) when NEXT_PUBLIC_MSW_ENABLED=true.
+ * NOT used in production builds.
+ */
+import { setupWorker } from 'msw/browser';
+import { allHandlers, setMockLoggedInUser } from './handlers';
+
+export const worker = setupWorker(...allHandlers);
+
+export async function startMockService(): Promise<void> {
+  await worker.start({
+    onUnhandledRequest: 'bypass',
+    serviceWorker: { url: '/mockServiceWorker.js' },
+  });
+}
+
+export const setMockUser = setMockLoggedInUser;

--- a/apps/web/src/tests/mocks/handlers/auth.handlers.ts
+++ b/apps/web/src/tests/mocks/handlers/auth.handlers.ts
@@ -106,18 +106,21 @@ export const authHandlers = [
    * Returns new access token.
    */
   http.post(`${BASE_URL}/api/v1/auth/refresh`, () => {
-    return HttpResponse.json({
-      accessToken: 'mock-access-token-refreshed-xyz',
-    });
+    // RefreshResponseSchema expects { accessToken: string } — no wrapper
+    return HttpResponse.json({ accessToken: 'ci-refresh-token' });
   }),
 
   /**
    * GET /api/v1/auth/me
    * Returns the currently logged-in user or 401 if not authenticated.
+   * auth.api.ts getMe() unwraps as wrapped.data → must return { success, data: User }
    */
   http.get(`${BASE_URL}/api/v1/auth/me`, () => {
     if (mockLoggedInUser) {
-      return HttpResponse.json(mockLoggedInUser, { status: 200 });
+      return HttpResponse.json(
+        { success: true, data: mockLoggedInUser },
+        { status: 200 },
+      );
     }
     return HttpResponse.json(
       { error: 'No autenticado' },

--- a/apps/web/src/tests/mocks/handlers/index.ts
+++ b/apps/web/src/tests/mocks/handlers/index.ts
@@ -14,3 +14,35 @@ export { usuariosHandlers } from './usuarios.handlers';
 export { maestrosHandlers } from './maestros.handlers';
 export { reportesHandlers } from './reportes.handlers';
 export { notificacionesHandlers } from './notificaciones.handlers';
+export { syncHandlers } from './sync.handlers';
+export { setMockLoggedInUser } from './auth.handlers';
+
+import { authHandlers } from './auth.handlers';
+import { prediosHandlers } from './predios.handlers';
+import { animalesHandlers } from './animales.handlers';
+import { serviciosHandlers } from './servicios.handlers';
+import { configHandlers } from './config.handlers';
+import { imagenesHandlers } from './imagenes.handlers';
+import { productosHandlers } from './productos.handlers';
+import { rolesHandlers } from './roles.handlers';
+import { usuariosHandlers } from './usuarios.handlers';
+import { maestrosHandlers } from './maestros.handlers';
+import { reportesHandlers } from './reportes.handlers';
+import { notificacionesHandlers } from './notificaciones.handlers';
+import { syncHandlers } from './sync.handlers';
+
+export const allHandlers = [
+  ...authHandlers,
+  ...prediosHandlers,
+  ...animalesHandlers,
+  ...serviciosHandlers,
+  ...configHandlers,
+  ...imagenesHandlers,
+  ...productosHandlers,
+  ...rolesHandlers,
+  ...usuariosHandlers,
+  ...maestrosHandlers,
+  ...reportesHandlers,
+  ...notificacionesHandlers,
+  ...syncHandlers,
+];


### PR DESCRIPTION
## Summary

- **SW installation fix**: `swUrl` corregido de `/sw.js` → `/serwist/sw.js`; idb-keyval con static imports para evitar chunks que fallan; `urlPattern` → `matcher` en Serwist v9
- **PWA gaps**: `manifest.json` con `id` y purpose split (`any` + `maskable` separados); offline URL alineado a `/offline`
- **SEO/a11y gaps**: `robots.txt` sin `Sitemap` roto; `(auth)/layout.tsx` con `<main id="main-content">` para skip links
- **LHCI MSW auth**: nuevo `MswProvider` + `browser.ts` + `lighthouse-auth.js` puppeteer script para auditar páginas autenticadas en CI
- **LHCI config**: `lighthouserc.desktop.json` y `lighthouserc.mobile.json` con collect blocks separados (login vs dashboard); quality.yml con `NEXT_PUBLIC_MSW_ENABLED` en build y start
- **Hardening (Judgment Day)**: auth handlers con formatos correctos (`auth/refresh` flat, `auth/me` con envelope); `auth-provider` rehidrata con `NEXT_PUBLIC_MSW_ENABLED`; `msw-provider` con `cancelled` flag y siempre renderiza children; `lighthouse-auth.js` con `domcontentloaded` y `try/finally`

## Test plan

- [ ] Verificar que el build pasa con `NEXT_PUBLIC_MSW_ENABLED=true`
- [ ] Verificar que el SW se instala correctamente en dev (`/serwist/sw.js`)
- [ ] Verificar que Lighthouse CI (desktop + mobile) corre sin errores de autenticación
- [ ] Verificar que `auth/me` retorna 200 en el puppeteer script
- [ ] Verificar scores de Lighthouse >= umbrales definidos en config