### PR TITLE
fix(types): corregir ~20 errores TypeScript en formularios RHF + Zod

### DIFF
--- a/apps/web/src/app/dashboard/predios/[id]/grupos/[grupoId]/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/grupos/[grupoId]/page.tsx
@@ -26,8 +26,13 @@ function GrupoDetailContent(): JSX.Element {
   const grupoId = grupoIdStr ? Number(grupoIdStr) : NaN;
 
   const { grupo, isLoading, error } = useGrupo({ id: grupoId, predioId: id });
-  const { mutate: deleteGrupo, isLoading: isDeleting } = useDeleteGrupo();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { mutate: deleteGrupo, isLoading: isDeleting } = useDeleteGrupo({
+    onSuccess: () => {
+      setShowDeleteModal(false);
+      router.push(`/dashboard/predios/${id}/grupos`);
+    },
+  });
 
   // Invalid IDs
   if (isNaN(id) || id <= 0 || isNaN(grupoId) || grupoId <= 0) {
@@ -49,12 +54,7 @@ function GrupoDetailContent(): JSX.Element {
   };
 
   const handleConfirmDelete = () => {
-    deleteGrupo(id, grupoId, {
-      onSuccess: () => {
-        setShowDeleteModal(false);
-        router.push(`/dashboard/predios/${id}/grupos`);
-      },
-    });
+    deleteGrupo(id, grupoId);
   };
 
   if (isLoading) {

--- a/apps/web/src/app/dashboard/predios/[id]/grupos/nuevo/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/grupos/nuevo/page.tsx
@@ -15,7 +15,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { CreateGrupoSchema, type CreateGrupoDto } from '@ganatrack/shared-types';
 import { useCreateGrupo } from '@/modules/predios/hooks';
-import { GrupoForm } from '@/modules/predios/components/grupo-form';
+import { GrupoForm, type GrupoFormData } from '@/modules/predios/components/grupo-form';
 import { Button } from '@/shared/components/ui/button';
 import { Skeleton } from '@/shared/components/ui/skeleton';
 
@@ -42,8 +42,8 @@ function NuevoGrupoContent(): JSX.Element {
     },
   });
 
-  const onSubmit = (data: CreateGrupoDto) => {
-    mutate(id, data);
+  const onSubmit = (data: GrupoFormData) => {
+    mutate(id, data as CreateGrupoDto);
   };
 
   const handleCancel = () => {

--- a/apps/web/src/app/dashboard/predios/[id]/lotes/[loteId]/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/lotes/[loteId]/page.tsx
@@ -26,8 +26,13 @@ function LoteDetailContent(): JSX.Element {
   const loteId = loteIdStr ? Number(loteIdStr) : NaN;
 
   const { lote, isLoading, error } = useLote({ id: loteId, predioId: id });
-  const { mutate: deleteLote, isLoading: isDeleting } = useDeleteLote();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { mutate: deleteLote, isLoading: isDeleting } = useDeleteLote({
+    onSuccess: () => {
+      setShowDeleteModal(false);
+      router.push(`/dashboard/predios/${id}/lotes`);
+    },
+  });
 
   // Invalid IDs
   if (isNaN(id) || id <= 0 || isNaN(loteId) || loteId <= 0) {
@@ -49,12 +54,7 @@ function LoteDetailContent(): JSX.Element {
   };
 
   const handleConfirmDelete = () => {
-    deleteLote(id, loteId, {
-      onSuccess: () => {
-        setShowDeleteModal(false);
-        router.push(`/dashboard/predios/${id}/lotes`);
-      },
-    });
+    deleteLote(id, loteId);
   };
 
   if (isLoading) {

--- a/apps/web/src/app/dashboard/predios/[id]/lotes/nuevo/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/lotes/nuevo/page.tsx
@@ -15,7 +15,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { CreateLoteSchema, type CreateLoteDto } from '@ganatrack/shared-types';
 import { useCreateLote } from '@/modules/predios/hooks';
-import { LoteForm } from '@/modules/predios/components/lote-form';
+import { LoteForm, type LoteFormData } from '@/modules/predios/components/lote-form';
 import { Button } from '@/shared/components/ui/button';
 import { Skeleton } from '@/shared/components/ui/skeleton';
 
@@ -43,8 +43,8 @@ function NuevoLoteContent(): JSX.Element {
     },
   });
 
-  const onSubmit = (data: CreateLoteDto) => {
-    mutate(id, data);
+  const onSubmit = (data: LoteFormData) => {
+    mutate(id, data as CreateLoteDto);
   };
 
   const handleCancel = () => {

--- a/apps/web/src/app/dashboard/predios/[id]/potreros/[potreroId]/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/potreros/[potreroId]/page.tsx
@@ -26,8 +26,13 @@ function PotreroDetailContent(): JSX.Element {
   const potreroId = potreroIdStr ? Number(potreroIdStr) : NaN;
 
   const { potrero, isLoading, error } = usePotrero({ id: potreroId, predioId: id });
-  const { mutate: deletePotrero, isLoading: isDeleting } = useDeletePotrero();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { mutate: deletePotrero, isLoading: isDeleting } = useDeletePotrero({
+    onSuccess: () => {
+      setShowDeleteModal(false);
+      router.push(`/dashboard/predios/${id}/potreros`);
+    },
+  });
 
   // Invalid IDs
   if (isNaN(id) || id <= 0 || isNaN(potreroId) || potreroId <= 0) {
@@ -49,12 +54,7 @@ function PotreroDetailContent(): JSX.Element {
   };
 
   const handleConfirmDelete = () => {
-    deletePotrero(id, potreroId, {
-      onSuccess: () => {
-        setShowDeleteModal(false);
-        router.push(`/dashboard/predios/${id}/potreros`);
-      },
-    });
+    deletePotrero(id, potreroId);
   };
 
   if (isLoading) {

--- a/apps/web/src/app/dashboard/predios/[id]/potreros/nuevo/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/potreros/nuevo/page.tsx
@@ -13,7 +13,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Suspense } from 'react';
 import { CreatePotreroSchema, type CreatePotreroDto } from '@ganatrack/shared-types';
 import { useCreatePotrero } from '@/modules/predios/hooks';
-import { PotreroForm } from '@/modules/predios/components/potrero-form';
+import { PotreroForm, type PotreroFormData } from '@/modules/predios/components/potrero-form';
 import { Skeleton } from '@/shared/components/ui/skeleton';
 import { Button } from '@/shared/components/ui/button';
 import Link from 'next/link';
@@ -45,8 +45,8 @@ function NuevoPotreroContent(): JSX.Element {
     },
   });
 
-  const onSubmit = (data: CreatePotreroDto) => {
-    mutate(id, data);
+  const onSubmit = (data: PotreroFormData) => {
+    mutate(id, data as CreatePotreroDto);
   };
 
   const handleCancel = () => {

--- a/apps/web/src/app/dashboard/predios/[id]/sectores/[sectorId]/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/sectores/[sectorId]/page.tsx
@@ -26,8 +26,13 @@ function SectorDetailContent(): JSX.Element {
   const sectorId = sectorIdStr ? Number(sectorIdStr) : NaN;
 
   const { sector, isLoading, error } = useSector({ id: sectorId, predioId: id });
-  const { mutate: deleteSector, isLoading: isDeleting } = useDeleteSector();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { mutate: deleteSector, isLoading: isDeleting } = useDeleteSector({
+    onSuccess: () => {
+      setShowDeleteModal(false);
+      router.push(`/dashboard/predios/${id}/sectores`);
+    },
+  });
 
   // Invalid IDs
   if (isNaN(id) || id <= 0 || isNaN(sectorId) || sectorId <= 0) {
@@ -49,12 +54,7 @@ function SectorDetailContent(): JSX.Element {
   };
 
   const handleConfirmDelete = () => {
-    deleteSector(id, sectorId, {
-      onSuccess: () => {
-        setShowDeleteModal(false);
-        router.push(`/dashboard/predios/${id}/sectores`);
-      },
-    });
+    deleteSector(id, sectorId);
   };
 
   if (isLoading) {

--- a/apps/web/src/app/dashboard/predios/[id]/sectores/nuevo/page.tsx
+++ b/apps/web/src/app/dashboard/predios/[id]/sectores/nuevo/page.tsx
@@ -15,7 +15,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { CreateSectorSchema, type CreateSectorDto } from '@ganatrack/shared-types';
 import { useCreateSector } from '@/modules/predios/hooks';
-import { SectorForm } from '@/modules/predios/components/sector-form';
+import { SectorForm, type SectorFormData } from '@/modules/predios/components/sector-form';
 import { Button } from '@/shared/components/ui/button';
 import { Skeleton } from '@/shared/components/ui/skeleton';
 
@@ -45,8 +45,8 @@ function NuevoSectorContent(): JSX.Element {
     },
   });
 
-  const onSubmit = (data: CreateSectorDto) => {
-    mutate(id, data);
+  const onSubmit = (data: SectorFormData) => {
+    mutate(id, data as CreateSectorDto);
   };
 
   const handleCancel = () => {

--- a/apps/web/src/modules/animales/components/animal-form.tsx
+++ b/apps/web/src/modules/animales/components/animal-form.tsx
@@ -177,7 +177,7 @@ const onFormSubmit = (data: AnimalFormData) => {
   const submitData: CreateAnimalDto = {
     ...data,
     fechaNacimiento: data.fechaNacimiento,
-    predicatesId: data.predioId ?? (predioActivo?.id ?? 0),
+    predioId: data.predioId ?? (predioActivo?.id ?? 0),
     potreroId: null, // Not captured in form, send as null
     madreId: data.madreId == null ? undefined : data.madreId,
     padreId: data.padreId == null ? undefined : data.padreId,

--- a/apps/web/src/modules/configuracion/components/catalogo-entity-page.tsx
+++ b/apps/web/src/modules/configuracion/components/catalogo-entity-page.tsx
@@ -27,6 +27,7 @@ import { Modal } from '@/shared/components/ui/modal';
 import { Button } from '@/shared/components/ui/button';
 import { useUiStore } from '@/store/ui.store';
 import { ApiError } from '@/shared/lib/errors';
+import { z } from 'zod';
 import type { CatalogoTipo, CatalogoBase, CatalogoConfig } from '../types/catalogo.types';
 import { CatalogoSchemas } from '../types/catalogo.types';
 
@@ -91,7 +92,7 @@ export function CatalogoEntityPage({
     setDeleteItem(item);
   };
 
-  const handleFormSubmit = async (data: Record<string, unknown>) => {
+  const handleFormSubmit = async (data: z.infer<typeof schema>) => {
     try {
       if (editItem) {
         await update({ id: editItem.id, data });

--- a/apps/web/src/modules/maestros/components/maestro-form.tsx
+++ b/apps/web/src/modules/maestros/components/maestro-form.tsx
@@ -28,7 +28,7 @@ import { Button } from '@/shared/components/ui/button';
 import type { MaestroFieldDef } from '../types/maestro.types';
 import type { z } from 'zod';
 
-interface MaestroFormProps<T extends z.ZodSchema> {
+interface MaestroFormProps<T extends z.ZodTypeAny> {
   fields: MaestroFieldDef[];
   schema: T;
   defaultValues?: z.infer<T>;
@@ -37,7 +37,7 @@ interface MaestroFormProps<T extends z.ZodSchema> {
   isLoading?: boolean;
 }
 
-export function MaestroForm<T extends z.ZodSchema>({
+export function MaestroForm<T extends z.ZodTypeAny>({
   fields,
   schema,
   defaultValues,

--- a/apps/web/src/modules/predios/components/grupo-form.tsx
+++ b/apps/web/src/modules/predios/components/grupo-form.tsx
@@ -22,10 +22,13 @@ import {
   type UpdateGrupoDto,
 } from '@ganatrack/shared-types';
 
-type GrupoFormData = CreateGrupoDto | UpdateGrupoDto;
+export type GrupoFormData = {
+  nombre?: string;
+  descripcion?: string;
+};
 
 interface GrupoFormProps {
-  initialData?: UpdateGrupoDto | null;
+  initialData?: GrupoFormData | null;
   onSubmit: (data: GrupoFormData) => void;
   isLoading?: boolean;
 }

--- a/apps/web/src/modules/predios/components/lote-form.tsx
+++ b/apps/web/src/modules/predios/components/lote-form.tsx
@@ -23,10 +23,14 @@ import {
   type LoteTipo,
 } from '@ganatrack/shared-types';
 
-type LoteFormData = CreateLoteDto | UpdateLoteDto;
+export type LoteFormData = {
+  nombre?: string;
+  descripcion?: string;
+  tipo?: 'producción' | 'levante' | 'engorde' | 'cría';
+};
 
 interface LoteFormProps {
-  initialData?: UpdateLoteDto | null;
+  initialData?: LoteFormData | null;
   onSubmit: (data: LoteFormData) => void;
   isLoading?: boolean;
 }

--- a/apps/web/src/modules/predios/components/potrero-form.tsx
+++ b/apps/web/src/modules/predios/components/potrero-form.tsx
@@ -23,10 +23,17 @@ import {
   type PotreroEstado,
 } from '@ganatrack/shared-types';
 
-type PotreroFormData = CreatePotreroDto | UpdatePotreroDto;
+export type PotreroFormData = {
+  codigo?: string;
+  nombre?: string;
+  areaHectareas?: number;
+  tipoPasto?: string;
+  capacidadMaxima?: number;
+  estado?: 'activo' | 'en_descanso';
+};
 
 interface PotreroFormProps {
-  initialData?: UpdatePotreroDto | null;
+  initialData?: PotreroFormData | null;
   onSubmit: (data: PotreroFormData) => void;
   isLoading?: boolean;
 }

--- a/apps/web/src/modules/predios/components/sector-form.tsx
+++ b/apps/web/src/modules/predios/components/sector-form.tsx
@@ -23,10 +23,17 @@ import {
   type SectorEstado,
 } from '@ganatrack/shared-types';
 
-type SectorFormData = CreateSectorDto | UpdateSectorDto;
+export type SectorFormData = {
+  codigo?: string;
+  nombre?: string;
+  areaHectareas?: number;
+  tipoPasto?: string;
+  capacidadMaxima?: number;
+  estado?: 'activo' | 'en_descanso';
+};
 
 interface SectorFormProps {
-  initialData?: UpdateSectorDto | null;
+  initialData?: SectorFormData | null;
   onSubmit: (data: SectorFormData) => void;
   isLoading?: boolean;
 }

--- a/apps/web/src/shared/components/ui/form-field.tsx
+++ b/apps/web/src/shared/components/ui/form-field.tsx
@@ -18,25 +18,31 @@
 
 'use client';
 
-import { Controller, type ControllerProps, type FieldValues, type ControllerRenderProps } from 'react-hook-form';
+import {
+  Controller,
+  type ControllerProps,
+  type FieldValues,
+  type FieldPath,
+  type ControllerRenderProps,
+} from 'react-hook-form';
 
-interface FormFieldProps<T extends FieldValues> {
-  name: ControllerProps<T>['name'];
+interface FormFieldProps<T extends FieldValues, K extends FieldPath<T>> {
+  name: K;
   label?: string;
   control: ControllerProps<T>['control'];
   rules?: ControllerProps<T>['rules'];
-  render: (field: ControllerRenderProps<T, ControllerProps<T>['name']> & { id: string }) => React.ReactNode;
+  render: (field: ControllerRenderProps<T, K> & { id: string }) => React.ReactNode;
   required?: boolean;
 }
 
-export function FormField<T extends FieldValues>({
+export function FormField<T extends FieldValues, K extends FieldPath<T>>({
   name,
   label,
   control,
   rules,
   render,
   required,
-}: FormFieldProps<T>): JSX.Element {
+}: FormFieldProps<T, K>): JSX.Element {
   const displayLabel = required && label ? `${label} (required)` : label;
   const fieldId = name.toString();
 

--- a/apps/web/src/shared/components/ui/input.tsx
+++ b/apps/web/src/shared/components/ui/input.tsx
@@ -31,7 +31,7 @@ interface InputBaseProps {
 export interface InputProps
   extends InputBaseProps,
     Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
-  type?: 'text' | 'email' | 'password' | 'number';
+  type?: 'text' | 'email' | 'password' | 'number' | 'date';
   as?: 'input';
 }
 


### PR DESCRIPTION
## Resumen

Corrige ~20 errores TypeScript en formularios que usan React Hook Form + Zod, causados por genéricos mal construidos en `FormField` y tipos inconsistentes.

## Cambios

### 1. FormField genéricos corregidos

**Archivo**: `shared/components/ui/form-field.tsx`

El componente `FormField` ahora usa `K extends FieldPath<T>` correctamente, haciendo que `field.value` en el `render` prop infiera el tipo específico del campo (ej: `Date`, `number`, `boolean`) en lugar de una unión de todos los tipos posibles.

**Impacto**: Elimina ~15 errores en `animal-form.tsx`, `usuario-form.tsx`, `predio-form.tsx`.

### 2. Input soporta type="date"

**Archivo**: `shared/components/ui/input.tsx`

Agregado `'date'` al union type de la prop `type`.

### 3. Campo predicatesId corregido

**Archivo**: `modules/animales/components/animal-form.tsx`

Cambiado `predicatesId` por `predioId` (el campo se renombró en el schema pero el formulario no se actualizó).

### 4. Tipos planos en formularios de predios

**Archivos**: `modules/predios/components/{grupo,lote,potrero,sector}-form.tsx`

Creados tipos planos opcionales (`GrupoFormData`, `LoteFormData`, `PotreroFormData`, `SectorFormData`) para usar en `useForm<>` en lugar de uniones `CreateXDto | UpdateXDto`.

**Archivos**: `app/dashboard/predios/[id]/*/{nuevo,[id]}/page.tsx`

Las páginas ahora usan los tipos planos y castean a `CreateXDto` al llamar `mutate`.

### 5. MaestroForm genéricos

**Archivo**: `modules/maestros/components/maestro-form.tsx`

Cambiado `z.ZodSchema` por `z.ZodTypeAny` (la API correcta de Zod v3).

**Archivo**: `modules/configuracion/components/catalogo-entity-page.tsx`

Ajustado `handleFormSubmit` para usar `z.infer<typeof schema>`.

## Test plan

- [x] `pnpm --filter @ganatrack/web test -- --run` pasa (515 tests)
- [x] `pnpm --filter @ganatrack/web typecheck` sin errores en archivos de formulario

Closes #14
