### PR TITLE
fix(tests): remove unused authenticatedPage parameter from e2e tests

### DIFF
--- a/apps/web/tests/e2e/animales-crud.spec.ts
+++ b/apps/web/tests/e2e/animales-crud.spec.ts
@@ -33,7 +33,7 @@ test.describe('CRUD Animales', () => {
   // =========================================================================
   // E2E-03 Scenario 1: Crear nuevo animal completo
   // =========================================================================
-  test('debería crear un nuevo animal con datos válidos', async ({ authenticatedPage }) => {
+  test('debería crear un nuevo animal con datos válidos', async () => {
     const page = animalesPage;
 
     // Navigate to create form
@@ -57,7 +57,7 @@ test.describe('CRUD Animales', () => {
   // =========================================================================
   // E2E-03 Scenario 2: Crear animal con código duplicado
   // =========================================================================
-  test('debería mostrar error al crear animal con código duplicado', async ({ authenticatedPage }) => {
+  test('debería mostrar error al crear animal con código duplicado', async () => {
     const page = animalesPage;
 
     // Navigate to create form
@@ -83,7 +83,7 @@ test.describe('CRUD Animales', () => {
   // =========================================================================
   // E2E-03 Scenario 3: Editar animal existente
   // =========================================================================
-  test('debería editar un animal existente', async ({ authenticatedPage }) => {
+  test('debería editar un animal existente', async () => {
     const page = animalesPage;
 
     // Navigate to edit for TEST_ANIMAL
@@ -110,7 +110,7 @@ test.describe('CRUD Animales', () => {
   // =========================================================================
   // E2E-03 Scenario 4: Cambiar estado del animal
   // =========================================================================
-  test('debería cambiar el estado del animal', async ({ authenticatedPage }) => {
+  test('debería cambiar el estado del animal', async () => {
     const page = animalesPage;
 
     // Navigate to animal detail
@@ -151,7 +151,7 @@ test.describe('CRUD Animales', () => {
   // =========================================================================
   // E2E-03 Scenario 5: Eliminar animal
   // =========================================================================
-  test('debería eliminar un animal con confirmación', async ({ authenticatedPage }) => {
+  test('debería eliminar un animal con confirmación', async () => {
     const page = animalesPage;
 
     // Navigate to detail page for TEST_ANIMAL_DELETE (dedicated animal for delete test)
@@ -184,7 +184,7 @@ test.describe('CRUD Animales', () => {
   // =========================================================================
   // E2E-03 Scenario 6: Validación de formulario vacío
   // =========================================================================
-  test('debería mostrar validación de campos obligatorios', async ({ authenticatedPage }) => {
+  test('debería mostrar validación de campos obligatorios', async () => {
     const page = animalesPage;
 
     // Navigate to create form
@@ -207,7 +207,7 @@ test.describe('CRUD Animales', () => {
   // =========================================================================
   // Additional: List page filtering
   // =========================================================================
-  test('debería filtrar animales por búsqueda', async ({ authenticatedPage }) => {
+  test('debería filtrar animales por búsqueda', async () => {
     const page = animalesPage;
 
     // Go to list

--- a/apps/web/tests/e2e/batch-operations.spec.ts
+++ b/apps/web/tests/e2e/batch-operations.spec.ts
@@ -31,7 +31,7 @@ test.describe('Operaciones en Lote - Animales', () => {
   // =========================================================================
   // E2E-08 Scenario 1: Selección múltiple de animales
   // =========================================================================
-  test('debería permitir seleccionar múltiples animales', async ({ authenticatedPage }) => {
+  test('debería permitir seleccionar múltiples animales', async () => {
     const page = animalesPage;
 
     // Select first animal checkbox
@@ -51,7 +51,7 @@ test.describe('Operaciones en Lote - Animales', () => {
   // =========================================================================
   // E2E-08 Scenario 2: Aplicar acción en lote - Cambiar estado
   // =========================================================================
-  test('debería cambiar estado de múltiples animales en lote', async ({ authenticatedPage }) => {
+  test('debería cambiar estado de múltiples animales en lote', async () => {
     const page = animalesPage;
 
     // Select multiple animals
@@ -97,7 +97,7 @@ test.describe('Operaciones en Lote - Animales', () => {
   // =========================================================================
   // E2E-08 Scenario 3: Aplicar acción en lote - Asignar potrero
   // =========================================================================
-  test('debería asignar potrero a múltiples animales en lote', async ({ authenticatedPage }) => {
+  test('debería asignar potrero a múltiples animales en lote', async () => {
     const page = animalesPage;
 
     // Select animals
@@ -135,7 +135,7 @@ test.describe('Operaciones en Lote - Animales', () => {
   // =========================================================================
   // E2E-08 Scenario 4: Selección de todos los animales
   // =========================================================================
-  test('debería seleccionar y deseleccionar todos los animales', async ({ authenticatedPage }) => {
+  test('debería seleccionar y deseleccionar todos los animales', async () => {
     const page = animalesPage;
 
     // Look for "select all" checkbox in table header
@@ -176,7 +176,7 @@ test.describe('Operaciones en Lote - Animales', () => {
   // =========================================================================
   // E2E-08 Scenario 5: Operación en lote con validación (delete confirmation)
   // =========================================================================
-  test('debería requerir confirmación para eliminar múltiples animales', async ({ authenticatedPage }) => {
+  test('debería requerir confirmación para eliminar múltiples animales', async () => {
     const page = animalesPage;
 
     // Select multiple animals

--- a/apps/web/tests/e2e/servicios-palpacion.spec.ts
+++ b/apps/web/tests/e2e/servicios-palpacion.spec.ts
@@ -26,7 +26,7 @@ test.describe('Wizard Palpación Grupal', () => {
   // =========================================================================
   // E2E-04 Scenario 1: Completar wizard de palpación grupal exitosamente
   // =========================================================================
-  test('debería completar el wizard de palpación exitosamente', async ({ authenticatedPage }) => {
+  test('debería completar el wizard de palpación exitosamente', async () => {
     const page = wizard;
 
     // Navigate to palpación wizard
@@ -85,7 +85,7 @@ test.describe('Wizard Palpación Grupal', () => {
   // =========================================================================
   // E2E-04 Scenario 2: Wizard palpación sin seleccionar animales
   // =========================================================================
-  test('debería mostrar error si no hay animales seleccionados', async ({ authenticatedPage }) => {
+  test('debería mostrar error si no hay animales seleccionados', async () => {
     const page = wizard;
 
     // Navigate to palpación wizard
@@ -109,7 +109,7 @@ test.describe('Wizard Palpación Grupal', () => {
   // =========================================================================
   // E2E-04 Scenario 3: Navegación entre pasos del wizard
   // =========================================================================
-  test('debería permitir navegación entre pasos preservando datos', async ({ authenticatedPage }) => {
+  test('debería permitir navegación entre pasos preservando datos', async () => {
     const page = wizard;
 
     // Navigate to palpación wizard
@@ -144,7 +144,7 @@ test.describe('Wizard Palpación Grupal', () => {
   // =========================================================================
   // E2E-04 Scenario 4: Cancelar wizard en cualquier paso
   // =========================================================================
-  test('debería cancelar wizard y no guardar datos', async ({ authenticatedPage }) => {
+  test('debería cancelar wizard y no guardar datos', async () => {
     const page = wizard;
 
     // Navigate to palpación wizard
@@ -176,7 +176,7 @@ test.describe('Wizard Palpación Grupal', () => {
   // =========================================================================
   // Additional: Validate step fields before proceeding
   // =========================================================================
-  test('debería validar campos obligatorios antes de avanzar', async ({ authenticatedPage }) => {
+  test('debería validar campos obligatorios antes de avanzar', async () => {
     const page = wizard;
 
     // Navigate to palpación wizard

--- a/apps/web/tests/e2e/servicios-parto.spec.ts
+++ b/apps/web/tests/e2e/servicios-parto.spec.ts
@@ -26,7 +26,7 @@ test.describe('Registro de Parto', () => {
   // =========================================================================
   // E2E-05 Scenario 1: Registrar parto exitoso con cria
   // =========================================================================
-  test('debería registrar parto exitoso con cria vinculada', async ({ authenticatedPage }) => {
+  test('debería registrar parto exitoso con cria vinculada', async () => {
     const page = wizard;
 
     // Navigate to parto wizard
@@ -86,7 +86,7 @@ test.describe('Registro de Parto', () => {
   // =========================================================================
   // E2E-05 Scenario 2: Registrar parto sin seleccionar madre
   // =========================================================================
-  test('debería mostrar error al registrar parto sin madre', async ({ authenticatedPage }) => {
+  test('debería mostrar error al registrar parto sin madre', async () => {
     const page = wizard;
 
     // Navigate to parto wizard
@@ -110,7 +110,7 @@ test.describe('Registro de Parto', () => {
   // =========================================================================
   // E2E-05 Scenario 3: Registrar parto con complicaciones
   // =========================================================================
-  test('debería registrar parto con complicaciones', async ({ authenticatedPage }) => {
+  test('debería registrar parto con complicaciones', async () => {
     const page = wizard;
 
     // Navigate to parto wizard
@@ -152,7 +152,7 @@ test.describe('Registro de Parto', () => {
   // =========================================================================
   // E2E-05 Scenario 4: Validar peso de cria fuera de rango
   // =========================================================================
-  test('debería mostrar warning para peso de cria fuera de rango', async ({ authenticatedPage }) => {
+  test('debería mostrar warning para peso de cria fuera de rango', async () => {
     const page = wizard;
 
     // Navigate to parto wizard
@@ -202,7 +202,7 @@ test.describe('Registro de Parto', () => {
   // =========================================================================
   // Additional: Cancel and preserve no data
   // =========================================================================
-  test('debería cancelar registro de parto sin guardar', async ({ authenticatedPage }) => {
+  test('debería cancelar registro de parto sin guardar', async () => {
     const page = wizard;
 
     // Navigate to parto wizard


### PR DESCRIPTION
Closes #24

## PR Type

- [x] Bug fix -> `type:bug`
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Removed unused `authenticatedPage` parameter from 22 e2e tests across 4 files
- Tests already create page objects in `beforeEach`, making the parameter redundant
- Eliminates lint warnings for unused variables in test files

## Changes

| File | Change |
|------|--------|
| `apps/web/tests/e2e/servicios-palpacion.spec.ts` | Removed `authenticatedPage` from 5 test signatures |
| `apps/web/tests/e2e/servicios-parto.spec.ts` | Removed `authenticatedPage` from 5 test signatures |
| `apps/web/tests/e2e/animales-crud.spec.ts` | Removed `authenticatedPage` from 7 test signatures |
| `apps/web/tests/e2e/batch-operations.spec.ts` | Removed `authenticatedPage` from 5 test signatures |

## Test Plan

- [x] Tests run without errors: `pnpm --filter web test`
- [x] Manually reviewed affected test files for correctness
- [x] No functional changes — parameter was already unused

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers