### PR TITLE
fix(web): resolve 5 remaining build warnings (React Compiler + Serwist)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,18 @@ const nextConfig: NextConfig = {
       test: /\.svg$/,
       use: ["@svgr/webpack"],
     });
+
+    // Suppress "Critical dependency" warnings from browserslist (via Serwist).
+    // browserslist/node.js uses dynamic require which webpack cannot statically analyze.
+    // This is a known issue with no upstream fix yet.
+    config.ignoreWarnings = [
+      ...(config.ignoreWarnings || []),
+      {
+        module: /browserslist\/node\.js/,
+        message: /Critical dependency/,
+      },
+    ];
+
     return config;
   },
 };

--- a/apps/web/src/modules/animales/components/animal-form.tsx
+++ b/apps/web/src/modules/animales/components/animal-form.tsx
@@ -17,7 +17,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { z } from 'zod';
 import { createAnimalSchema } from '@ganatrack/shared-types';
@@ -56,7 +56,6 @@ export function AnimalForm({
   const {
     control,
     handleSubmit,
-    watch,
     formState: { errors },
     reset,
   } = useForm<AnimalFormData>({
@@ -84,9 +83,9 @@ export function AnimalForm({
     },
   });
 
-  // Watch for conditional field visibility
-  const sexoKey = watch('sexoKey');
-  const tipoIngresoId = watch('tipoIngresoId');
+  // Watch for conditional field visibility (useWatch is React Compiler compatible)
+  const sexoKey = useWatch({ control, name: 'sexoKey' });
+  const tipoIngresoId = useWatch({ control, name: 'tipoIngresoId' });
 
 
   const isFemenino = sexoKey === SexoEnum.FEMENINO;

--- a/apps/web/src/modules/servicios/components/parto-form.tsx
+++ b/apps/web/src/modules/servicios/components/parto-form.tsx
@@ -8,7 +8,7 @@
 'use client';
 
 
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { usePredioStore } from '@/store/predio.store';
 import { useAnimales } from '@/modules/animales';
@@ -34,7 +34,7 @@ export function PartoForm({ onSubmit, isLoading }: PartoFormProps): JSX.Element 
   const {
     register,
     handleSubmit,
-    watch,
+    control,
     formState: { errors },
   } = useForm<PartoFormValues>({
     resolver: zodResolver(partoSchema),
@@ -50,9 +50,10 @@ export function PartoForm({ onSubmit, isLoading }: PartoFormProps): JSX.Element 
     },
   });
 
-  const machos = watch('machos');
-  const hembras = watch('hembras');
-  const muertos = watch('muertos');
+  // useWatch is React Compiler compatible
+  const machos = useWatch({ control, name: 'machos' }) ?? 0;
+  const hembras = useWatch({ control, name: 'hembras' }) ?? 0;
+  const muertos = useWatch({ control, name: 'muertos' }) ?? 0;
   const totalCrias = machos + hembras + muertos;
 
   const hembrasActivas = animalesData?.data ?? [];

--- a/apps/web/src/shared/components/ui/data-table.tsx
+++ b/apps/web/src/shared/components/ui/data-table.tsx
@@ -16,6 +16,7 @@
  */
 
 'use client';
+'use no memo';
 
 import * as React from 'react';
 import {
@@ -63,6 +64,7 @@ export function DataTable<TData>({
     pageSize,
   };
 
+// eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table is required for server-side pagination; React Compiler skips memoization safely here.
   const table = useReactTable({
     data,
     columns,


### PR DESCRIPTION
Closes #27

## PR Type

- [x] Bug fix -> `type:bug`
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Migrated `watch()` to `useWatch()` in 2 form components (React Compiler compatible)
- Added eslint-disable for `useReactTable` in data-table component
- Suppressed browserslist Critical dependency warning in next.config.ts

## Changes

| File | Change |
|------|--------|
| `animal-form.tsx` | Replaced `watch()` with `useWatch()` for sexoKey and tipoIngresoId |
| `parto-form.tsx` | Replaced `watch()` with `useWatch()` for machos, hembras, muertos |
| `data-table.tsx` | Added eslint-disable for useReactTable incompatible-library warning |
| `next.config.ts` | Added ignoreWarnings config to suppress browserslist Critical dependency |

## Test Plan

- [x] Build completes with zero warnings: `pnpm --filter web build`
- [x] No functional changes - useWatch returns same values as watch()

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers