### PR TITLE
fix(web): renombrar idCounter a _idCounter en notificaciones.mock.ts

### DIFF
--- a/apps/web/src/modules/notificaciones/services/notificaciones.mock.ts
+++ b/apps/web/src/modules/notificaciones/services/notificaciones.mock.ts
@@ -96,7 +96,7 @@ const defaultPreferencias: NotificacionPreferencias = {
 
 let preferencias = { ...defaultPreferencias };
 
-let idCounter = 6;
+let _idCounter = 6;
 
 // ============================================================================
 // Helpers
@@ -190,6 +190,6 @@ export class MockNotificacionesService implements INotificacionesService {
 export function resetNotificacionesMock(): void {
   storeNotificaciones.length = 0;
   storeNotificaciones.push(...SEED_NOTIFICACIONES.map((n) => ({ ...n })));
-  idCounter = 6;
+  _idCounter = 6;
   preferencias = { ...defaultPreferencias };
 }


### PR DESCRIPTION
Closes #30

## PR Type

- [x] Bug fix -> `type:bug`
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Renombrada variable `idCounter` a `_idCounter` para eliminar warning de ESLint
- La regla `varsIgnorePattern: '^_'` permite variables con prefijo underscore

## Changes

| File | Change |
|------|--------|
| `notificaciones.mock.ts` | Renombrada variable para cumplir con ESLint |

## Test Plan

- [x] Build sin warnings de ESLint
- [x] No hay cambios funcionales

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers