### PR TITLE
feat(pwa): Phase 2 — Types, queue infrastructure, and offline status

### DIFF
--- a/apps/web/src/shared/hooks/__tests__/use-offline-queue.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-offline-queue.test.ts
@@ -1,0 +1,236 @@
+// apps/web/src/shared/hooks/__tests__/use-offline-queue.test.ts
+/**
+ * Tests for use-offline-queue.ts — React hook for offline queue management.
+ *
+ * Coverage targets:
+ * - Returns queueCount, isOnline, add, remove, peek, flush
+ * - Subscribes to online/offline events
+ * - Refreshes queueCount on operations
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// Mock form-queue operations
+const mockQueueItems: unknown[] = [];
+
+vi.mock('@/shared/lib/offline/form-queue', () => ({
+  enqueue: vi.fn(async (item: unknown) => {
+    mockQueueItems.push(item);
+  }),
+  remove: vi.fn(async (id: string) => {
+    const idx = mockQueueItems.findIndex(
+      (it: Record<string, unknown>) => it.id === id,
+    );
+    if (idx >= 0) mockQueueItems.splice(idx, 1);
+  }),
+  peek: vi.fn(async () => {
+    return mockQueueItems[0] ?? null;
+  }),
+  flush: vi.fn(async () => {
+    mockQueueItems.length = 0;
+  }),
+  getStatus: vi.fn(async () => ({
+    count: mockQueueItems.length,
+    isEmpty: mockQueueItems.length === 0,
+  })),
+}));
+
+describe('useOfflineQueue', () => {
+  beforeEach(() => {
+    mockQueueItems.length = 0;
+    // Default to online
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('debería retornar queueCount inicial 0 y isOnline true', async () => {
+    const { useOfflineQueue } = await import('../use-offline-queue');
+    const { result } = renderHook(() => useOfflineQueue());
+
+    expect(result.current.queueCount).toBe(0);
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('debería incrementar queueCount al agregar un item', async () => {
+    const { useOfflineQueue } = await import('../use-offline-queue');
+    const { result } = renderHook(() => useOfflineQueue());
+
+    const item = {
+      id: '550e8400-e29b-41d4-a716-446655440001',
+      formType: 'animal' as const,
+      payload: { nombre: 'Vaca' },
+      idempotencyKey: 'key-1',
+      endpoint: '/api/v1/animales',
+      method: 'POST' as const,
+      predioId: 42,
+      createdAt: Date.now(),
+      attempts: 0,
+      status: 'pending' as const,
+    };
+
+    await act(async () => {
+      await result.current.add(item);
+    });
+
+    await waitFor(() => {
+      expect(result.current.queueCount).toBe(1);
+    });
+  });
+
+  it('debería decrementar queueCount al remover un item', async () => {
+    const { useOfflineQueue } = await import('../use-offline-queue');
+    const { result } = renderHook(() => useOfflineQueue());
+
+    const item = {
+      id: '550e8400-e29b-41d4-a716-446655440002',
+      formType: 'animal' as const,
+      payload: { nombre: 'Vaca' },
+      idempotencyKey: 'key-2',
+      endpoint: '/api/v1/animales',
+      method: 'POST' as const,
+      predioId: 42,
+      createdAt: Date.now(),
+      attempts: 0,
+      status: 'pending' as const,
+    };
+
+    await act(async () => {
+      await result.current.add(item);
+    });
+
+    await waitFor(() => {
+      expect(result.current.queueCount).toBe(1);
+    });
+
+    await act(async () => {
+      await result.current.remove(item.id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.queueCount).toBe(0);
+    });
+  });
+
+  it('debería retornar el item más antiguo con peek', async () => {
+    const { useOfflineQueue } = await import('../use-offline-queue');
+    const { result } = renderHook(() => useOfflineQueue());
+
+    const item = {
+      id: '550e8400-e29b-41d4-a716-446655440003',
+      formType: 'animal' as const,
+      payload: { nombre: 'Vaca' },
+      idempotencyKey: 'key-3',
+      endpoint: '/api/v1/animales',
+      method: 'POST' as const,
+      predioId: 42,
+      createdAt: Date.now(),
+      attempts: 0,
+      status: 'pending' as const,
+    };
+
+    await act(async () => {
+      await result.current.add(item);
+    });
+
+    let peeked: typeof item | null = null;
+    await act(async () => {
+      peeked = await result.current.peek();
+    });
+
+    expect(peeked?.id).toBe(item.id);
+  });
+
+  it('debería limpiar la cola con flush', async () => {
+    const { useOfflineQueue } = await import('../use-offline-queue');
+    const { result } = renderHook(() => useOfflineQueue());
+
+    const item = {
+      id: '550e8400-e29b-41d4-a716-446655440004',
+      formType: 'animal' as const,
+      payload: { nombre: 'Vaca' },
+      idempotencyKey: 'key-4',
+      endpoint: '/api/v1/animales',
+      method: 'POST' as const,
+      predioId: 42,
+      createdAt: Date.now(),
+      attempts: 0,
+      status: 'pending' as const,
+    };
+
+    await act(async () => {
+      await result.current.add(item);
+    });
+
+    await waitFor(() => {
+      expect(result.current.queueCount).toBe(1);
+    });
+
+    await act(async () => {
+      await result.current.flush();
+    });
+
+    await waitFor(() => {
+      expect(result.current.queueCount).toBe(0);
+    });
+  });
+
+  it('debería actualizar isOnline cuando cambia la conectividad', async () => {
+    const { useOfflineQueue } = await import('../use-offline-queue');
+    const { result } = renderHook(() => useOfflineQueue());
+
+    expect(result.current.isOnline).toBe(true);
+
+    act(() => {
+      Object.defineProperty(window.navigator, 'onLine', {
+        value: false,
+        writable: true,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isOnline).toBe(false);
+    });
+
+    act(() => {
+      Object.defineProperty(window.navigator, 'onLine', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isOnline).toBe(true);
+    });
+  });
+
+  it('debería remover listeners al desmontar', async () => {
+    const { useOfflineQueue } = await import('../use-offline-queue');
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useOfflineQueue());
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'online',
+      expect.any(Function),
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'offline',
+      expect.any(Function),
+    );
+
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -1,6 +1,7 @@
 export { useDebounce } from './use-debounce';
 export { useFailedSync } from './use-failed-sync';
 export { useMediaQuery, useIsMobile, useIsTablet, useIsDesktop } from './use-media-query';
+export { useOfflineQueue } from './use-offline-queue';
 export { useOnlineStatus } from './use-online-status';
 export { usePagination } from './use-pagination';
 export { usePredioRequerido } from './use-predio-requerido';

--- a/apps/web/src/shared/hooks/use-offline-queue.ts
+++ b/apps/web/src/shared/hooks/use-offline-queue.ts
@@ -1,0 +1,128 @@
+// apps/web/src/shared/hooks/use-offline-queue.ts
+/**
+ * useOfflineQueue — React hook for managing the offline form queue.
+ *
+ * Provides:
+ * - queueCount: Current number of items in the queue
+ * - isOnline: Browser connectivity status
+ * - add(item): Add a form item to the queue
+ * - remove(id): Remove an item by id
+ * - peek(): Return the oldest item without removing
+ * - flush(): Clear all items from the queue
+ *
+ * Automatically refreshes queueCount after every operation.
+ * Subscribes to online/offline events.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  enqueue,
+  remove as removeFromQueue,
+  peek as peekQueue,
+  flush as flushQueue,
+  getStatus,
+} from '@/shared/lib/offline/form-queue';
+import type { FormQueueItem } from '@/shared/lib/offline/types';
+
+export interface UseOfflineQueueReturn {
+  /** Current number of items in the queue */
+  queueCount: number;
+  /** Whether the browser is online */
+  isOnline: boolean;
+  /** Add a form item to the queue */
+  add: (item: FormQueueItem) => Promise<void>;
+  /** Remove an item from the queue by id */
+  remove: (id: string) => Promise<void>;
+  /** Return the oldest item without removing */
+  peek: () => Promise<FormQueueItem | null>;
+  /** Clear all items from the queue */
+  flush: () => Promise<void>;
+}
+
+/**
+ * Hook for managing the offline form submission queue.
+ *
+ * @returns Queue state and operations
+ */
+export function useOfflineQueue(): UseOfflineQueueReturn {
+  const [queueCount, setQueueCount] = useState<number>(0);
+  const [isOnline, setIsOnline] = useState<boolean>(() => {
+    if (typeof navigator !== 'undefined') return navigator.onLine;
+    return true;
+  });
+
+  /**
+   * Refresh the queue count from IndexedDB.
+   */
+  const refreshCount = useCallback(async () => {
+    const status = await getStatus();
+    setQueueCount(status.count);
+  }, []);
+
+  // Initialize queue count on mount
+  useEffect(() => {
+    void refreshCount();
+  }, [refreshCount]);
+
+  // Subscribe to online/offline events
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  /**
+   * Add an item to the queue and refresh count.
+   */
+  const add = useCallback(
+    async (item: FormQueueItem) => {
+      await enqueue(item);
+      await refreshCount();
+    },
+    [refreshCount],
+  );
+
+  /**
+   * Remove an item from the queue and refresh count.
+   */
+  const remove = useCallback(
+    async (id: string) => {
+      await removeFromQueue(id);
+      await refreshCount();
+    },
+    [refreshCount],
+  );
+
+  /**
+   * Peek at the oldest item without removing.
+   */
+  const peek = useCallback(async () => {
+    return await peekQueue();
+  }, []);
+
+  /**
+   * Clear all items from the queue and refresh count.
+   */
+  const flush = useCallback(async () => {
+    await flushQueue();
+    await refreshCount();
+  }, [refreshCount]);
+
+  return {
+    queueCount,
+    isOnline,
+    add,
+    remove,
+    peek,
+    flush,
+  };
+}

--- a/apps/web/src/shared/lib/offline/__tests__/form-queue.test.ts
+++ b/apps/web/src/shared/lib/offline/__tests__/form-queue.test.ts
@@ -1,0 +1,225 @@
+// apps/web/src/shared/lib/offline/__tests__/form-queue.test.ts
+/**
+ * Tests for form-queue.ts — IndexedDB queue operations.
+ *
+ * Coverage targets:
+ * - enqueue adds item to queue
+ * - dequeue removes oldest item
+ * - peek returns oldest without removing
+ * - flush clears all items
+ * - getAll returns all items
+ * - getStatus returns count and empty flag
+ * - FIFO eviction when queue exceeds 50 items
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock idb-keyval before importing form-queue
+const mockStore = new Map<string, unknown>();
+
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(async (key: string) => mockStore.get(key) ?? undefined),
+  set: vi.fn(async (key: string, value: unknown) => {
+    mockStore.set(key, value);
+  }),
+  del: vi.fn(async (key: string) => {
+    mockStore.delete(key);
+  }),
+}));
+
+import type { FormQueueItem, FormType } from '../types';
+
+let mockIdCounter = 0;
+
+function nextUUID(): string {
+  mockIdCounter++;
+  // Generate valid v4-like UUIDs: 550e8400-e29b-41d4-a716-44665544xxxx
+  return `550e8400-e29b-41d4-a716-44665544${String(mockIdCounter).padStart(4, '0')}`;
+}
+
+function createMockItem(overrides?: Partial<FormQueueItem>): FormQueueItem {
+  const now = Date.now();
+  return {
+    id: nextUUID(),
+    formType: 'animal' as FormType,
+    payload: { nombre: 'Test' },
+    idempotencyKey: `key-${now}-${mockIdCounter}`,
+    endpoint: '/api/v1/animales',
+    method: 'POST',
+    predioId: 42,
+    createdAt: now,
+    attempts: 0,
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+describe('form-queue', () => {
+  beforeEach(() => {
+    mockStore.clear();
+  });
+
+  describe('enqueue', () => {
+    it('debería agregar un item a la cola vacía', async () => {
+      const { enqueue, getAll } = await import('../form-queue');
+      const item = createMockItem();
+
+      await enqueue(item);
+      const items = await getAll();
+
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe(item.id);
+    });
+
+    it('debería agregar múltiples items en orden FIFO', async () => {
+      const { enqueue, getAll } = await import('../form-queue');
+      const item1 = createMockItem({ createdAt: 1000 });
+      const item2 = createMockItem({ createdAt: 2000 });
+
+      await enqueue(item1);
+      await enqueue(item2);
+      const items = await getAll();
+
+      expect(items).toHaveLength(2);
+      expect(items[0].id).toBe(item1.id);
+      expect(items[1].id).toBe(item2.id);
+    });
+
+    it('debería evictar el item más antiguo cuando se excede el límite de 50', async () => {
+      const { enqueue, getAll } = await import('../form-queue');
+
+      // Enqueue 51 items
+      const firstItem = createMockItem({ createdAt: 1000 });
+      await enqueue(firstItem);
+
+      for (let i = 0; i < 50; i++) {
+        await enqueue(createMockItem({ createdAt: 2000 + i }));
+      }
+
+      const items = await getAll();
+      expect(items).toHaveLength(50);
+      expect(items.some((it) => it.id === firstItem.id)).toBe(false); // Oldest evicted
+    });
+  });
+
+  describe('dequeue', () => {
+    it('debería retornar null cuando la cola está vacía', async () => {
+      const { dequeue } = await import('../form-queue');
+      const result = await dequeue();
+      expect(result).toBeNull();
+    });
+
+    it('debería remover y retornar el item más antiguo', async () => {
+      const { enqueue, dequeue, getAll } = await import('../form-queue');
+      const item1 = createMockItem({ createdAt: 1000 });
+      const item2 = createMockItem({ createdAt: 2000 });
+
+      await enqueue(item1);
+      await enqueue(item2);
+
+      const dequeued = await dequeue();
+      const remaining = await getAll();
+
+      expect(dequeued?.id).toBe(item1.id);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe(item2.id);
+    });
+  });
+
+  describe('peek', () => {
+    it('debería retornar null cuando la cola está vacía', async () => {
+      const { peek } = await import('../form-queue');
+      const result = await peek();
+      expect(result).toBeNull();
+    });
+
+    it('debería retornar el item más antiguo sin removerlo', async () => {
+      const { enqueue, peek, getAll } = await import('../form-queue');
+      const item1 = createMockItem({ createdAt: 1000 });
+      const item2 = createMockItem({ createdAt: 2000 });
+
+      await enqueue(item1);
+      await enqueue(item2);
+
+      const peeked = await peek();
+      const all = await getAll();
+
+      expect(peeked?.id).toBe(item1.id);
+      expect(all).toHaveLength(2);
+    });
+  });
+
+  describe('flush', () => {
+    it('debería limpiar todos los items', async () => {
+      const { enqueue, flush, getAll } = await import('../form-queue');
+      await enqueue(createMockItem());
+      await enqueue(createMockItem());
+
+      await flush();
+      const items = await getAll();
+
+      expect(items).toHaveLength(0);
+    });
+
+    it('debería funcionar en cola vacía sin error', async () => {
+      const { flush, getAll } = await import('../form-queue');
+      await flush();
+      const items = await getAll();
+      expect(items).toHaveLength(0);
+    });
+  });
+
+  describe('getAll', () => {
+    it('debería retornar array vacío cuando no hay items', async () => {
+      const { getAll } = await import('../form-queue');
+      const items = await getAll();
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('debería retornar count 0 y isEmpty true para cola vacía', async () => {
+      const { getStatus } = await import('../form-queue');
+      const status = await getStatus();
+
+      expect(status.count).toBe(0);
+      expect(status.isEmpty).toBe(true);
+    });
+
+    it('debería retornar count correcto y isEmpty false', async () => {
+      const { enqueue, getStatus } = await import('../form-queue');
+      await enqueue(createMockItem());
+      await enqueue(createMockItem());
+
+      const status = await getStatus();
+      expect(status.count).toBe(2);
+      expect(status.isEmpty).toBe(false);
+    });
+  });
+
+  describe('remove', () => {
+    it('debería remover un item por su id', async () => {
+      const { enqueue, remove, getAll } = await import('../form-queue');
+      const item1 = createMockItem();
+      const item2 = createMockItem();
+
+      await enqueue(item1);
+      await enqueue(item2);
+      await remove(item1.id);
+
+      const items = await getAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe(item2.id);
+    });
+
+    it('debería no hacer nada si el id no existe', async () => {
+      const { enqueue, remove, getAll } = await import('../form-queue');
+      const item = createMockItem();
+      await enqueue(item);
+
+      await remove('550e8400-e29b-41d4-a716-446655449999');
+      const items = await getAll();
+      expect(items).toHaveLength(1);
+    });
+  });
+});

--- a/apps/web/src/shared/lib/offline/__tests__/types.test.ts
+++ b/apps/web/src/shared/lib/offline/__tests__/types.test.ts
@@ -1,0 +1,158 @@
+// apps/web/src/shared/lib/offline/__tests__/types.test.ts
+/**
+ * Tests for offline queue types — zod schemas, idempotency key generation.
+ *
+ * Coverage targets:
+ * - FormQueueItem zod schema validates valid/invalid items
+ * - generateIdempotencyKey produces correct format
+ * - Constants are exported correctly
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('offline/types', () => {
+  describe('generateIdempotencyKey', () => {
+    it('debería generar una key con formato uuid-timestamp-formType', async () => {
+      const { generateIdempotencyKey } = await import('../types');
+      const key = generateIdempotencyKey('animal');
+
+      const pattern =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-\d{13}-(animal|palpacion|parto)$/;
+      expect(key).toMatch(pattern);
+      expect(key.endsWith('-animal')).toBe(true);
+    });
+
+    it('debería generar keys únicas para llamadas sucesivas', async () => {
+      const { generateIdempotencyKey } = await import('../types');
+      const key1 = generateIdempotencyKey('animal');
+      const key2 = generateIdempotencyKey('animal');
+
+      expect(key1).not.toBe(key2);
+    });
+
+    it('debería incluir el formType correcto en la key', async () => {
+      const { generateIdempotencyKey } = await import('../types');
+      const animalKey = generateIdempotencyKey('animal');
+      const palpacionKey = generateIdempotencyKey('palpacion');
+      const partoKey = generateIdempotencyKey('parto');
+
+      expect(animalKey.endsWith('-animal')).toBe(true);
+      expect(palpacionKey.endsWith('-palpacion')).toBe(true);
+      expect(partoKey.endsWith('-parto')).toBe(true);
+    });
+
+    it('debería lanzar error para formType inválido', async () => {
+      const { generateIdempotencyKey } = await import('../types');
+      expect(() => generateIdempotencyKey('invalid' as never)).toThrow();
+    });
+  });
+
+  describe('formQueueItemSchema', () => {
+    it('debería validar un item válido', async () => {
+      const { formQueueItemSchema } = await import('../types');
+      const validItem = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        formType: 'animal',
+        payload: { nombre: 'Vaca Test' },
+        idempotencyKey: '550e8400-e29b-41d4-a716-446655440000-1716000000000-animal',
+        endpoint: '/api/v1/animales',
+        method: 'POST',
+        predioId: 42,
+        createdAt: Date.now(),
+        attempts: 0,
+        status: 'pending',
+      };
+
+      const result = formQueueItemSchema.safeParse(validItem);
+      expect(result.success).toBe(true);
+    });
+
+    it('debería rechazar un item con formType inválido', async () => {
+      const { formQueueItemSchema } = await import('../types');
+      const invalidItem = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        formType: 'invalid',
+        payload: { nombre: 'Vaca Test' },
+        idempotencyKey: '550e8400-e29b-41d4-a716-446655440000-1716000000000-animal',
+        endpoint: '/api/v1/animales',
+        method: 'POST',
+        predioId: 42,
+        createdAt: Date.now(),
+        attempts: 0,
+        status: 'pending',
+      };
+
+      const result = formQueueItemSchema.safeParse(invalidItem);
+      expect(result.success).toBe(false);
+    });
+
+    it('debería rechazar un item con method distinto de POST', async () => {
+      const { formQueueItemSchema } = await import('../types');
+      const invalidItem = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        formType: 'animal',
+        payload: { nombre: 'Vaca Test' },
+        idempotencyKey: '550e8400-e29b-41d4-a716-446655440000-1716000000000-animal',
+        endpoint: '/api/v1/animales',
+        method: 'GET',
+        predioId: 42,
+        createdAt: Date.now(),
+        attempts: 0,
+        status: 'pending',
+      };
+
+      const result = formQueueItemSchema.safeParse(invalidItem);
+      expect(result.success).toBe(false);
+    });
+
+    it('debería rechazar un item con status inválido', async () => {
+      const { formQueueItemSchema } = await import('../types');
+      const invalidItem = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        formType: 'animal',
+        payload: { nombre: 'Vaca Test' },
+        idempotencyKey: '550e8400-e29b-41d4-a716-446655440000-1716000000000-animal',
+        endpoint: '/api/v1/animales',
+        method: 'POST',
+        predioId: 42,
+        createdAt: Date.now(),
+        attempts: 0,
+        status: 'unknown',
+      };
+
+      const result = formQueueItemSchema.safeParse(invalidItem);
+      expect(result.success).toBe(false);
+    });
+
+    it('debería aceptar campos opcionales omitidos', async () => {
+      const { formQueueItemSchema } = await import('../types');
+      const itemWithoutOptional = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        formType: 'palpacion',
+        payload: { fecha: '2024-01-01' },
+        idempotencyKey: '550e8400-e29b-41d4-a716-446655440000-1716000000000-palpacion',
+        endpoint: '/api/v1/servicios/palpaciones',
+        method: 'POST',
+        predioId: 7,
+        createdAt: Date.now(),
+        attempts: 0,
+        status: 'pending',
+      };
+
+      const result = formQueueItemSchema.safeParse(itemWithoutOptional);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('constants', () => {
+    it('debería exportar QUEUE_KEY con valor ganatrack-form-queue', async () => {
+      const { QUEUE_KEY } = await import('../types');
+      expect(QUEUE_KEY).toBe('ganatrack-form-queue');
+    });
+
+    it('debería exportar MAX_QUEUE_SIZE con valor 50', async () => {
+      const { MAX_QUEUE_SIZE } = await import('../types');
+      expect(MAX_QUEUE_SIZE).toBe(50);
+    });
+  });
+});

--- a/apps/web/src/shared/lib/offline/form-queue.ts
+++ b/apps/web/src/shared/lib/offline/form-queue.ts
@@ -1,0 +1,142 @@
+// apps/web/src/shared/lib/offline/form-queue.ts
+/**
+ * Form Queue — IndexedDB-based queue for offline form submissions.
+ *
+ * Uses idb-keyval for consistent storage with the service worker.
+ * Supports FIFO eviction when max size (50) is exceeded.
+ *
+ * Operations:
+ * - enqueue: Add item to queue (evicts oldest if over limit)
+ * - dequeue: Remove and return oldest item
+ * - peek: Return oldest item without removing
+ * - remove: Remove item by id
+ * - flush: Clear all items
+ * - getAll: Return all items
+ * - getStatus: Return queue metadata (count, empty flag)
+ */
+
+import { get, set, del } from 'idb-keyval';
+import { QUEUE_KEY, MAX_QUEUE_SIZE, formQueueItemSchema } from './types';
+import type { FormQueueItem } from './types';
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+/**
+ * Reads the current queue from IndexedDB.
+ */
+async function readQueue(): Promise<FormQueueItem[]> {
+  const data = await get<FormQueueItem[]>(QUEUE_KEY);
+  return data ?? [];
+}
+
+/**
+ * Writes the queue to IndexedDB.
+ */
+async function writeQueue(items: FormQueueItem[]): Promise<void> {
+  await set(QUEUE_KEY, items);
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Adds a validated form item to the queue.
+ * If the queue exceeds MAX_QUEUE_SIZE, the oldest item is removed (FIFO eviction).
+ *
+ * @param item - The form queue item to enqueue
+ * @throws Error if the item fails schema validation
+ */
+export async function enqueue(item: FormQueueItem): Promise<void> {
+  const parsed = formQueueItemSchema.safeParse(item);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid form queue item: ${parsed.error.message}`,
+    );
+  }
+
+  const queue = await readQueue();
+  queue.push(parsed.data);
+
+  // FIFO eviction: remove oldest items if over limit
+  while (queue.length > MAX_QUEUE_SIZE) {
+    queue.shift();
+  }
+
+  await writeQueue(queue);
+}
+
+/**
+ * Removes and returns the oldest item from the queue.
+ *
+ * @returns The oldest item, or null if the queue is empty
+ */
+export async function dequeue(): Promise<FormQueueItem | null> {
+  const queue = await readQueue();
+  if (queue.length === 0) return null;
+
+  const item = queue.shift()!;
+  await writeQueue(queue);
+  return item;
+}
+
+/**
+ * Returns the oldest item without removing it.
+ *
+ * @returns The oldest item, or null if the queue is empty
+ */
+export async function peek(): Promise<FormQueueItem | null> {
+  const queue = await readQueue();
+  if (queue.length === 0) return null;
+  return queue[0] ?? null;
+}
+
+/**
+ * Removes an item from the queue by its id.
+ *
+ * @param id - The id of the item to remove
+ */
+export async function remove(id: string): Promise<void> {
+  const queue = await readQueue();
+  const filtered = queue.filter((item) => item.id !== id);
+  await writeQueue(filtered);
+}
+
+/**
+ * Clears all items from the queue.
+ */
+export async function flush(): Promise<void> {
+  await del(QUEUE_KEY);
+}
+
+/**
+ * Returns all items in the queue (oldest first).
+ *
+ * @returns Array of form queue items
+ */
+export async function getAll(): Promise<FormQueueItem[]> {
+  return readQueue();
+}
+
+/**
+ * Queue status metadata.
+ */
+export interface QueueStatus {
+  count: number;
+  isEmpty: boolean;
+}
+
+/**
+ * Returns the current queue status.
+ *
+ * @returns Object with count and isEmpty flag
+ */
+export async function getStatus(): Promise<QueueStatus> {
+  const queue = await readQueue();
+  return {
+    count: queue.length,
+    isEmpty: queue.length === 0,
+  };
+}

--- a/apps/web/src/shared/lib/offline/types.ts
+++ b/apps/web/src/shared/lib/offline/types.ts
@@ -1,0 +1,125 @@
+// apps/web/src/shared/lib/offline/types.ts
+/**
+ * Offline Queue Types — Zod schemas and TypeScript interfaces for form queue.
+ *
+ * Provides:
+ * - FormQueueItem schema and type
+ * - Idempotency key generation
+ * - Queue constants
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * IndexedDB key for the form queue.
+ */
+export const QUEUE_KEY = 'ganatrack-form-queue';
+
+/**
+ * Maximum number of items in the form queue.
+ * When exceeded, oldest items are evicted (FIFO).
+ */
+export const MAX_QUEUE_SIZE = 50;
+
+// ============================================================================
+// Zod Schemas
+// ============================================================================
+
+/**
+ * Valid form types that can be queued.
+ */
+export const FormTypeEnum = z.enum(['animal', 'palpacion', 'parto']);
+
+/**
+ * Valid queue item statuses.
+ */
+export const QueueStatusEnum = z.enum([
+  'pending',
+  'submitting',
+  'failed',
+  'completed',
+]);
+
+/**
+ * Zod schema for a form queue item.
+ * Validates data before enqueueing to IndexedDB.
+ */
+export const formQueueItemSchema = z.object({
+  id: z.string().uuid(),
+  formType: FormTypeEnum,
+  payload: z.record(z.unknown()),
+  idempotencyKey: z.string(),
+  endpoint: z.string().min(1),
+  method: z.literal('POST'),
+  predioId: z.number().int().positive(),
+  createdAt: z.number().int(),
+  attempts: z.number().int().min(0).default(0),
+  lastAttemptAt: z.number().int().optional(),
+  status: QueueStatusEnum,
+});
+
+// ============================================================================
+// TypeScript Types
+// ============================================================================
+
+/**
+ * Type for form queue items.
+ * Derived from the Zod schema for runtime + compile-time safety.
+ */
+export type FormQueueItem = z.infer<typeof formQueueItemSchema>;
+
+/**
+ * Type for form types.
+ */
+export type FormType = z.infer<typeof FormTypeEnum>;
+
+/**
+ * Type for queue item statuses.
+ */
+export type QueueStatus = z.infer<typeof QueueStatusEnum>;
+
+// ============================================================================
+// Idempotency Key Generation
+// ============================================================================
+
+/**
+ * Generates a UUID v4 string.
+ * Uses crypto.randomUUID when available, falls back to manual generation.
+ */
+function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  // Fallback for environments without crypto.randomUUID
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Generates an idempotency key for form submissions.
+ *
+ * Format: `{uuid-v4}-{timestamp-ms}-{form-type}`
+ * Example: `a1b2c3d4-e5f6-7890-abcd-ef1234567890-1716000000000-animal`
+ *
+ * @param formType - The type of form being submitted
+ * @returns A globally unique idempotency key
+ * @throws Error if formType is invalid
+ */
+export function generateIdempotencyKey(formType: FormType): string {
+  const parsed = FormTypeEnum.safeParse(formType);
+  if (!parsed.success) {
+    throw new Error(`Invalid form type: ${formType}`);
+  }
+
+  const uuid = generateUUID();
+  const timestamp = Date.now();
+  return `${uuid}-${timestamp}-${parsed.data}`;
+}

--- a/apps/web/src/shared/providers/__tests__/offline-status-provider.test.tsx
+++ b/apps/web/src/shared/providers/__tests__/offline-status-provider.test.tsx
@@ -1,0 +1,121 @@
+// apps/web/src/shared/providers/__tests__/offline-status-provider.test.tsx
+/**
+ * Tests for offline-status-provider.tsx — Offline status context provider.
+ *
+ * Coverage targets:
+ * - Provides isOnline and queueCount to children
+ * - Children render correctly within provider
+ * - Default values are correct
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+
+// Mock idb-keyval before importing provider
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(async () => []),
+  set: vi.fn(async () => {}),
+  del: vi.fn(async () => {}),
+}));
+
+describe('OfflineStatusProvider', () => {
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('debería proveer isOnline=true por defecto', async () => {
+    const {
+      OfflineStatusProvider,
+      useOfflineStatus,
+    } = await import('../offline-status-provider');
+
+    function TestChild() {
+      const { isOnline } = useOfflineStatus();
+      return <div data-testid="online">{isOnline ? 'online' : 'offline'}</div>;
+    }
+
+    render(
+      <OfflineStatusProvider>
+        <TestChild />
+      </OfflineStatusProvider>,
+    );
+
+    expect(screen.getByTestId('online').textContent).toBe('online');
+  });
+
+  it('debería proveer queueCount=0 por defecto', async () => {
+    const {
+      OfflineStatusProvider,
+      useOfflineStatus,
+    } = await import('../offline-status-provider');
+
+    function TestChild() {
+      const { queueCount } = useOfflineStatus();
+      return <div data-testid="count">{queueCount}</div>;
+    }
+
+    render(
+      <OfflineStatusProvider>
+        <TestChild />
+      </OfflineStatusProvider>,
+    );
+
+    expect(screen.getByTestId('count').textContent).toBe('0');
+  });
+
+  it('debería actualizar isOnline al cambiar conectividad', async () => {
+    const {
+      OfflineStatusProvider,
+      useOfflineStatus,
+    } = await import('../offline-status-provider');
+
+    function TestChild() {
+      const { isOnline } = useOfflineStatus();
+      return <div data-testid="online">{isOnline ? 'online' : 'offline'}</div>;
+    }
+
+    render(
+      <OfflineStatusProvider>
+        <TestChild />
+      </OfflineStatusProvider>,
+    );
+
+    expect(screen.getByTestId('online').textContent).toBe('online');
+
+    // Simulate going offline
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('online').textContent).toBe('offline');
+    });
+  });
+
+  it('debería lanzar error si useOfflineStatus se usa fuera del provider', async () => {
+    const { useOfflineStatus } = await import('../offline-status-provider');
+
+    function BadComponent() {
+      const status = useOfflineStatus();
+      return <div>{status.isOnline ? 'yes' : 'no'}</div>;
+    }
+
+    // Suppress console.error for this test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<BadComponent />)).toThrow(
+      'useOfflineStatus must be used within an OfflineStatusProvider',
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/web/src/shared/providers/offline-status-provider.tsx
+++ b/apps/web/src/shared/providers/offline-status-provider.tsx
@@ -1,0 +1,117 @@
+// apps/web/src/shared/providers/offline-status-provider.tsx
+/**
+ * OfflineStatusProvider — React context for offline/online status and queue count.
+ *
+ * Provides:
+ * - isOnline: Browser connectivity status
+ * - queueCount: Number of pending items in the offline form queue
+ *
+ * Used by components that need to show offline indicators or queue badges.
+ */
+
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import { getStatus } from '@/shared/lib/offline/form-queue';
+
+export interface OfflineStatus {
+  /** Whether the browser is currently online */
+  isOnline: boolean;
+  /** Number of items in the offline form queue */
+  queueCount: number;
+}
+
+const OfflineStatusContext = createContext<OfflineStatus | null>(null);
+
+interface OfflineStatusProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Provider that tracks online/offline status and queue count.
+ *
+ * @example
+ * <OfflineStatusProvider>
+ *   <App />
+ * </OfflineStatusProvider>
+ */
+export function OfflineStatusProvider({
+  children,
+}: OfflineStatusProviderProps): JSX.Element {
+  const [isOnline, setIsOnline] = useState<boolean>(() => {
+    if (typeof navigator !== 'undefined') return navigator.onLine;
+    return true;
+  });
+  const [queueCount, setQueueCount] = useState<number>(0);
+
+  // Subscribe to online/offline events
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  // Refresh queue count periodically and on visibility change
+  useEffect(() => {
+    const refreshQueueCount = async () => {
+      const status = await getStatus();
+      setQueueCount(status.count);
+    };
+
+    refreshQueueCount();
+
+    // Refresh when tab becomes visible
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refreshQueueCount();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    // Periodic refresh every 30 seconds
+    const intervalId = setInterval(refreshQueueCount, 30000);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  return (
+    <OfflineStatusContext.Provider value={{ isOnline, queueCount }}>
+      {children}
+    </OfflineStatusContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the offline status context.
+ *
+ * @returns Offline status (isOnline, queueCount)
+ * @throws Error if used outside of OfflineStatusProvider
+ */
+export function useOfflineStatus(): OfflineStatus {
+  const context = useContext(OfflineStatusContext);
+
+  if (context === null) {
+    throw new Error(
+      'useOfflineStatus must be used within an OfflineStatusProvider',
+    );
+  }
+
+  return context;
+}

--- a/apps/web/src/sw.ts
+++ b/apps/web/src/sw.ts
@@ -255,15 +255,14 @@ const serwist = new Serwist({
       }),
     },
 
-    // 5. Catalogs — NetworkFirst (user can mutate via CRUD; must show fresh data)
+    // 5. Catalogs — StaleWhileRevalidate (serve cached instantly, refresh in background)
     {
       matcher: ({ url }) =>
         /\/api\/v1\/(configuracion|maestros)\//.test(url.pathname),
-      handler: new NetworkFirst({
+      handler: new StaleWhileRevalidate({
         cacheName: "api-catalogs",
-        networkTimeoutSeconds: 3,
         plugins: [
-          new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 3600 }),
+          new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 300 }), // 5 minutes
         ],
       }),
       method: "GET",


### PR DESCRIPTION
Closes #32

- [x] New feature

## Summary

Phase 2 implementation of PWA offline + Background Sync — types, queue infrastructure, and catalog precaching.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/shared/lib/offline/types.ts` | Zod schemas, FormQueueItem type, generateIdempotencyKey() |
| `apps/web/src/shared/lib/offline/form-queue.ts` | IndexedDB queue with enqueue/dequeue/peek/remove/flush, FIFO eviction at 50 |
| `apps/web/src/shared/hooks/use-offline-queue.ts` | React hook: queueCount, isOnline, add/remove/peek/flush |
| `apps/web/src/shared/providers/offline-status-provider.tsx` | Context provider for global isOnline + queueCount |
| `apps/web/src/sw.ts` | Switch catalog caching to StaleWhileRevalidate with 5min TTL |
| `apps/web/src/shared/hooks/index.ts` | Export useOfflineQueue |

## Tests

- 36 new tests (11 types + 14 queue + 7 hook + 4 provider)
- All 563 tests passing
- Build succeeds

## Test Plan

- [x] Scripts run without errors
- [x] All tests pass: `pnpm --filter web test`
- [x] Build succeeds: `pnpm --filter web build`

## Chain Context

- **Phase**: 2 of 3 (Types + Queue Infrastructure)
- **Prior**: Phase 1 (Auth headers + SW toast) — PR #33 merged
- **Follow-up**: Phase 3 (Backend idempotency + Form wiring)
- **Out of scope**: Phase 3 tasks, E2E tests

## Dependency Diagram

```
main
 └── feature/pwa-offline-background-sync (tracker)
      └── PR #1: Phase 1 (auth-fix + toast) ✅ merged
      └── 📍 PR #2: Phase 2 (types + queue) ← THIS PR
      └── PR #3: Phase 3 (api + forms) — pending
```