### PR TITLE
fix(web): resolver 4 warnings de ESLint en build (#43)

### DIFF
--- a/apps/web/src/app/dashboard/animales/nuevo/page.tsx
+++ b/apps/web/src/app/dashboard/animales/nuevo/page.tsx
@@ -37,7 +37,7 @@ export default function NuevoAnimalPage(): JSX.Element {
         payload: data as Record<string, unknown>,
         endpoint: '/api/v1/animales',
         predioId,
-        submitFn: async (headers) => {
+        submitFn: async (_headers) => {
           return mutateAsync({
             ...data,
             predioId,

--- a/apps/web/src/app/dashboard/servicios/palpaciones/nuevo/page.tsx
+++ b/apps/web/src/app/dashboard/servicios/palpaciones/nuevo/page.tsx
@@ -37,23 +37,6 @@ export default function NuevaPalpacionPage(): JSX.Element | null {
   const [resultados, setResultados] = useState<Record<number, CreatePalpacionAnimalDto>>({});
   const [isOfflineQueued, setIsOfflineQueued] = useState(false);
 
-  if (predioLoading || !predioActivo) return null;
-
-  const handleNextStep1 = async () => {
-    const isValid = await formRef.current?.trigger();
-    if (isValid) {
-      const values = formRef.current?.getValues();
-      if (values) {
-        setEventoData(values);
-        setStep(2);
-      }
-    }
-  };
-
-  const handleResultadoChange = (animalId: number, data: CreatePalpacionAnimalDto) => {
-    setResultados((prev) => ({ ...prev, [animalId]: data }));
-  };
-
   const handleSubmit = useCallback(async () => {
     if (!eventoData) return;
 
@@ -93,6 +76,23 @@ export default function NuevaPalpacionPage(): JSX.Element | null {
       console.error('Error creating palpacion:', err);
     }
   }, [eventoData, selectedAnimals, resultados, mutateAsync, router]);
+
+  if (predioLoading || !predioActivo) return null;
+
+  const handleNextStep1 = async () => {
+    const isValid = await formRef.current?.trigger();
+    if (isValid) {
+      const values = formRef.current?.getValues();
+      if (values) {
+        setEventoData(values);
+        setStep(2);
+      }
+    }
+  };
+
+  const handleResultadoChange = (animalId: number, data: CreatePalpacionAnimalDto) => {
+    setResultados((prev) => ({ ...prev, [animalId]: data }));
+  };
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/dashboard/servicios/partos/nuevo/page.tsx
+++ b/apps/web/src/app/dashboard/servicios/partos/nuevo/page.tsx
@@ -25,11 +25,9 @@ export default function NuevoPartoPage(): JSX.Element | null {
   const { mutateAsync, isPending, error } = useCreateParto();
   const [isOfflineQueued, setIsOfflineQueued] = useState(false);
 
-  if (predioLoading || !predioActivo) return null;
-
   const handleSubmit = useCallback(async (data: CreatePartoDto) => {
     const isOnline = navigator.onLine;
-    const predioId = predioActivo.id;
+    const predioId = predioActivo?.id ?? 0;
 
     try {
       const result = await submitFormWithOfflineSupport({
@@ -54,7 +52,9 @@ export default function NuevoPartoPage(): JSX.Element | null {
     } catch (err) {
       console.error('Error creating parto:', err);
     }
-  }, [mutateAsync, predioActivo.id, router]);
+  }, [mutateAsync, predioActivo?.id, router]);
+
+  if (predioLoading || !predioActivo) return null;
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/shared/hooks/use-offline-queue.ts
+++ b/apps/web/src/shared/hooks/use-offline-queue.ts
@@ -63,8 +63,10 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
 
   // Initialize queue count on mount
   useEffect(() => {
-    void refreshCount();
-  }, [refreshCount]);
+    getStatus().then((status) => {
+      setQueueCount(status.count);
+    });
+  }, []);
 
   // Subscribe to online/offline events
   useEffect(() => {


### PR DESCRIPTION
Closes #43

## Cambios

Resuelve los 4 warnings de ESLint que ensuciaban el build de `@ganatrack/web`.

### Archivos modificados

| Archivo | Warning | Fix |
|---------|---------|-----|
| `animales/nuevo/page.tsx` | `no-unused-vars` — `headers` sin usar | Renombrado a `_headers` |
| `palpaciones/nuevo/page.tsx` | `rules-of-hooks` — `useCallback` después de early return | Movido antes del return condicional |
| `partos/nuevo/page.tsx` | `rules-of-hooks` — `useCallback` después de early return | Movido antes del return condicional + optional chaining |
| `use-offline-queue.ts` | `set-state-in-effect` — `setState` sincrónico en `useEffect` | Reemplazado por `getStatus().then()` |

### Notas

- Los fixes de `rules-of-hooks` corrigen violaciones graves de la regla de oro de React Hooks (llamar hooks siempre en el mismo orden, antes de cualquier return condicional).
- El fix en `use-offline-queue.ts` evita renders en cascada causados por `setState" sincrónico dentro de un effect.
- `pnpm build` ahora pasa limpio sin warnings de ESLint.