### PR TITLE
fix(api): agregar If-Match y X-Resource-Version a CORS headers

### DIFF
--- a/apps/api/src/plugins/cors.plugin.ts
+++ b/apps/api/src/plugins/cors.plugin.ts
@@ -7,8 +7,8 @@ export async function corsPlugin(app: FastifyInstance): Promise<void> {
     origin: true,
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'Cookie', 'x-predio-id', 'x-tenant-id'],
-    exposedHeaders: ['Content-Length', 'Content-Type'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'Cookie', 'x-predio-id', 'x-tenant-id', 'If-Match'],
+    exposedHeaders: ['Content-Length', 'Content-Type', 'X-Resource-Version'],
     maxAge: 86400,
   })
 
@@ -19,7 +19,7 @@ export async function corsPlugin(app: FastifyInstance): Promise<void> {
       reply.header('Access-Control-Allow-Origin', origin ?? '*')
       reply.header('Access-Control-Allow-Credentials', 'true')
       reply.header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
-      reply.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cookie, x-predio-id, x-tenant-id')
+      reply.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cookie, x-predio-id, x-tenant-id, If-Match')
       reply.header('Access-Control-Max-Age', '86400')
       return reply.status(204).send()
     }


### PR DESCRIPTION
## Descripción

Corrige error CORS al editar animales después de agregar el header `If-Match`.

### Problema
El frontend envía correctamente el header `If-Match`, pero el backend no lo incluye en `Access-Control-Allow-Headers`, bloqueando la petición en el preflight OPTIONS.

### Cambios

- Agrega `If-Match` a `allowedHeaders` del plugin CORS (@fastify/cors)
- Agrega `If-Match` al header `Access-Control-Allow-Headers` del preflight manual (onRequest hook)
- Expone `X-Resource-Version` en `Access-Control-Expose-Headers" para que el frontend pueda leerlo

### Archivos modificados
- `apps/api/src/plugins/cors.plugin.ts`

Closes #47